### PR TITLE
fix: pass MCP_TIMEOUT to SDK callTool requests

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -301,10 +301,14 @@ export async function callTool(
   args: Record<string, unknown>,
 ): Promise<unknown> {
   return withRetry(async () => {
-    const result = await client.callTool({
-      name: toolName,
-      arguments: args,
-    });
+    const result = await client.callTool(
+      {
+        name: toolName,
+        arguments: args,
+      },
+      undefined,
+      { timeout: getTimeoutMs() },
+    );
     return result;
   }, `call tool ${toolName}`);
 }


### PR DESCRIPTION
The typescript MCP SDK has a hardcoded DEFAULT_REQUEST_TIMEOUT_MSEC of 60 seconds. Without passing the timeout option to client.callTool(), the MCP_TIMEOUT environment variable was being ignored for tool execution, causing long-running tools (like browser automation) to fail with error -32001 (RequestTimeout) after 60 seconds regardless of the configured timeout.

This fix passes getTimeoutMs() to the SDK's callTool options, ensuring the user-configured MCP_TIMEOUT is respected.