### PR TITLE
SSE Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.1] - 2026-02-03
+
+### Added
+
+- **SSE Transport Support** - Support for Server-Sent Events transport protocol
+  - Requires `type: "sse"` in server config
+  - Enables connection to MCP servers using SSE (e.g. LangChain, remote servers)
+
 ## [0.3.0] - 2026-01-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -299,6 +299,24 @@ The CLI uses `mcp_servers.json`, compatible with Claude Desktop, Gemini or VS Co
 }
 ```
 
+### SSE Transport (Legacy)
+
+For servers using the deprecated SSE transport protocol, add `"type": "sse"` to the configuration:
+
+```json
+{
+  "mcpServers": {
+    "legacy-server": {
+      "url": "http://localhost:8000",
+      "type": "sse"
+    }
+  }
+}
+```
+
+> [!NOTE]
+> SSE transport is deprecated. New servers should use Streamable HTTP transport.
+
 **Environment Variable Substitution:** Use `${VAR_NAME}` syntax anywhere in the config. Values are substituted at load time. By default, missing environment variables cause an error with a clear message. Set `MCP_STRICT_ENV=false` to use empty values instead (with a warning).
 
 ### Tool Filtering

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A lightweight CLI for interacting with MCP (Model Context Protocol) servers",
   "type": "module",
   "main": "src/index.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,10 +48,22 @@ export interface HttpServerConfig extends BaseServerConfig {
   url: string;
   headers?: Record<string, string>;
   timeout?: number;
-  transport?: 'sse';
 }
 
-export type ServerConfig = StdioServerConfig | HttpServerConfig;
+/**
+ * SSE server configuration (remote) - uses SSE transport
+ */
+export interface SseServerConfig extends BaseServerConfig {
+  url: string;
+  headers?: Record<string, string>;
+  timeout?: number;
+  type: 'sse';
+}
+
+export type ServerConfig =
+  | StdioServerConfig
+  | HttpServerConfig
+  | SseServerConfig;
 
 export interface McpServersConfig {
   mcpServers: Record<string, ServerConfig>;
@@ -145,10 +157,17 @@ export function isToolAllowed(toolName: string, config: ServerConfig): boolean {
 }
 
 /**
+ * Check if a server config is SSE-based
+ */
+export function isSseServer(config: ServerConfig): config is SseServerConfig {
+  return 'url' in config && (config as SseServerConfig).type === 'sse';
+}
+
+/**
  * Check if a server config is HTTP-based
  */
 export function isHttpServer(config: ServerConfig): config is HttpServerConfig {
-  return 'url' in config;
+  return 'url' in config && !isSseServer(config);
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,6 +48,7 @@ export interface HttpServerConfig extends BaseServerConfig {
   url: string;
   headers?: Record<string, string>;
   timeout?: number;
+  transport?: 'sse';
 }
 
 export type ServerConfig = StdioServerConfig | HttpServerConfig;

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,4 +2,4 @@
  * Version constant - single source of truth
  * This file is auto-updated by scripts/release.sh
  */
-export const VERSION = '0.3.0';
+export const VERSION = '0.3.1';

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -11,6 +11,7 @@ import {
   getServerConfig,
   listServerNames,
   isHttpServer,
+  isSseServer,
   isStdioServer,
 } from '../src/config';
 
@@ -50,7 +51,7 @@ describe('config', () => {
           mcpServers: {
             sse: {
               url: 'http://localhost:3000/sse',
-              transport: 'sse',
+              type: 'sse',
             },
           },
         }),
@@ -58,7 +59,7 @@ describe('config', () => {
 
       const config = await loadConfig(configPath);
       expect(config.mcpServers.sse).toBeDefined();
-      expect((config.mcpServers.sse as any).transport).toBe('sse');
+      expect((config.mcpServers.sse as any).type).toBe('sse');
     });
 
     test('throws on missing config file', async () => {
@@ -252,6 +253,17 @@ describe('config', () => {
     test('isHttpServer identifies HTTP config', () => {
       expect(isHttpServer({ url: 'https://example.com' })).toBe(true);
       expect(isHttpServer({ command: 'echo' })).toBe(false);
+      expect(isHttpServer({ url: 'https://example.com', type: 'sse' })).toBe(
+        false,
+      );
+    });
+
+    test('isSseServer identifies SSE config', () => {
+      expect(isSseServer({ url: 'https://example.com', type: 'sse' })).toBe(
+        true,
+      );
+      expect(isSseServer({ url: 'https://example.com' })).toBe(false);
+      expect(isSseServer({ command: 'echo' })).toBe(false);
     });
 
     test('isStdioServer identifies stdio config', () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -42,6 +42,25 @@ describe('config', () => {
       expect((config.mcpServers.test as any).command).toBe('echo');
     });
 
+    test('loads server with sse transport', async () => {
+      const configPath = join(tempDir, 'sse_config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            sse: {
+              url: 'http://localhost:3000/sse',
+              transport: 'sse',
+            },
+          },
+        }),
+      );
+
+      const config = await loadConfig(configPath);
+      expect(config.mcpServers.sse).toBeDefined();
+      expect((config.mcpServers.sse as any).transport).toBe('sse');
+    });
+
     test('throws on missing config file', async () => {
       const configPath = join(tempDir, 'nonexistent.json');
       await expect(loadConfig(configPath)).rejects.toThrow('not found');


### PR DESCRIPTION
 **SSE Transport Support** - Support for Server-Sent Events transport protocol
  - Requires `type: "sse"` in server config
  - Enables connection to MCP servers using SSE (e.g. LangChain, remote servers)
