### PR TITLE
fix: call command outputs raw text content instead of MCP envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@
 
 - **3-Subcommand Architecture** - `info`, `grep`, `call`
   - Flexible format support: `server tool` and `server/tool`
-  - `call` always outputs raw JSON (for piping/scripting)
-  - `info`/`grep` always output human-readable format
+  - `call` outputs raw text content (CLI-friendly, pipe to grep/head/etc.)
+  - `info`/`grep` output human-readable format
 
 - **Improved Error Messages for LLMs**
   - AMBIGUOUS_COMMAND: Shows both `call` and `info` options

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -29,7 +29,7 @@ import {
   toolExecutionError,
   toolNotFoundError,
 } from '../errors.js';
-import { formatJson } from '../output.js';
+import { formatJson, formatToolResult } from '../output.js';
 
 export interface CallOptions {
   target: string; // "server/tool"
@@ -161,8 +161,9 @@ export async function callCommand(options: CallOptions): Promise<void> {
   try {
     const result = await connection.callTool(toolName, args);
 
-    // Always output raw JSON for programmatic use
-    console.log(formatJson(result));
+    // Extract text content from MCP response for CLI-friendly output
+    // Uses formatToolResult which extracts text from MCP content array
+    console.log(formatToolResult(result));
   } catch (error) {
     // Try to get available tools for better error message
     let availableTools: string[] | undefined;

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -241,6 +241,28 @@ describe('CLI Integration Tests', () => {
       // We just verify it doesn't crash
       expect(typeof result.exitCode).toBe('number');
     });
+
+    test('outputs raw text content, not MCP envelope (issue #25)', async () => {
+      // This test ensures the call command outputs raw text content
+      // instead of the full MCP protocol envelope like:
+      // { "content": [{ "type": "text", "text": "..." }] }
+      const result = await runCli([
+        'call',
+        'filesystem',
+        'read_file',
+        JSON.stringify({ path: testFilePath }),
+      ]);
+
+      expect(result.exitCode).toBe(0);
+
+      // Output should be the raw file content
+      expect(result.stdout).toContain('Hello from test file!');
+
+      // Output should NOT contain MCP envelope structure
+      expect(result.stdout).not.toContain('"content"');
+      expect(result.stdout).not.toContain('"type"');
+      expect(result.stdout).not.toContain('"text"');
+    });
   });
 
   describe('error handling', () => {


### PR DESCRIPTION
Fixes #25

## Problem
The `call` command was outputting the full MCP protocol envelope:
```json
{ "content": [{ "type": "text", "text": "..." }] }
```

This made it hard to pipe output to `jq`, `grep`, `head`, etc. without extracting `.content[0].text`.

## Solution
Now outputs raw text content directly, restoring the v0.1.4 behavior.

## Changes
- Use existing `formatToolResult` helper in `call.ts`
- Update `SKILL.md` examples (remove jq extraction patterns)
- Update `CHANGELOG.md` to reflect correct behavior
- Add e2e test to prevent regression

## Before/After
```bash
# Before (v0.3.0)
$ mcp-cli call server/tool '{}'
{ "content": [{ "type": "text", "text": "[...]" }] }

# After
$ mcp-cli call server/tool '{}'
[...]  # Raw text, directly pipeable
```