### PR TITLE
fix: scope env var warnings to the server being queried

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -496,14 +496,17 @@ export async function loadConfig(
     }
   }
 
-  // Substitute environment variables
-  config = substituteEnvVarsInObject(config);
+  // Environment variable substitution is deferred to getServerConfig()
+  // so that warnings/errors only appear for the server being accessed.
 
   return config;
 }
 
 /**
- * Get a specific server config by name
+ * Get a specific server config by name.
+ *
+ * Environment variables are substituted lazily here so that missing-var
+ * warnings are scoped to the server being queried (fixes #20).
  */
 export function getServerConfig(
   config: McpServersConfig,
@@ -514,7 +517,7 @@ export function getServerConfig(
     const available = Object.keys(config.mcpServers);
     throw new Error(formatCliError(serverNotFoundError(serverName, available)));
   }
-  return server;
+  return substituteEnvVarsInObject(server);
 }
 
 /**


### PR DESCRIPTION
## Problem

When running `mcp-cli info <server>`, warnings about missing environment variables appear for ALL servers in the config, not just the one being queried (#20). This creates unnecessary noise, especially when using mcp-cli with AI agents.

## Root Cause

`substituteEnvVarsInObject()` was called on the entire config at parse time (`parseConfig`), resolving env vars for every server upfront.

## Fix

Defer env var substitution to `getServerConfig()`, so variables are only resolved for the server being accessed. This means:

- `mcp-cli info chrome-devtools` only warns about chrome-devtools' env vars
- `mcp-cli list` resolves each server individually, showing warnings per-server
- `listServerNames()` (keys only) is unaffected

## Changes

- `src/config.ts`: Remove eager `substituteEnvVarsInObject(config)` from `parseConfig()`, add it to `getServerConfig()` return

Fixes #20