### PR TITLE
feat: add getVersion() helper function

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,16 @@
 /**
  * Version constant - single source of truth
  * This file is auto-updated by scripts/release.sh
+ * @constant {string} VERSION - The current CLI version
+ * @example
+ * console.log(VERSION); // '0.3.0'
  */
 export const VERSION = '0.3.0';
+
+/**
+ * Get version info for CLI output
+ * @returns {string} Formatted version string with v prefix
+ */
+export function getVersion(): string {
+  return `v${VERSION}`;
+}


### PR DESCRIPTION
## Summary

Add getVersion() helper function to format version string for CLI output.

## Changes Made

- Add JSDoc comments to VERSION constant with usage example
- Add getVersion() helper function that returns "v" + VERSION
- Improves code reusability for version display across CLI

## Testing

- No functional changes to existing code
- New function can be used in future version output formatting

## Checklist

- [x] Code follows project style
- [x] Documentation added (JSDoc)
- [x] Self-reviewed