### PR TITLE
docs: improve install prerequisite wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ A lightweight, Bun-based CLI for interacting with [MCP (Model Context Protocol)]
 curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh | bash
 ```
 
-or 
+or
 
 ```bash
-# requires bun install
+# requires Bun to be installed
 bun install -g https://github.com/philschmid/mcp-cli
 ```
 


### PR DESCRIPTION
## Summary\nClarify the global install prerequisite wording in README.\n\n## Change\n- Replace  with \n\n## Why\nThe previous wording is ambiguous and reads like a command typo; this makes the requirement clear for new users.\n