### PR TITLE
fix: handle stdout backpressure for large tool output

### DIFF
--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -163,7 +163,12 @@ export async function callCommand(options: CallOptions): Promise<void> {
 
     // Extract text content from MCP response for CLI-friendly output
     // Uses formatToolResult which extracts text from MCP content array
-    console.log(formatToolResult(result));
+    const output = `${formatToolResult(result)}\n`;
+    if (!process.stdout.write(output)) {
+      await new Promise<void>((resolve) => {
+        process.stdout.once('drain', resolve);
+      });
+    }
   } catch (error) {
     // Try to get available tools for better error message
     let availableTools: string[] | undefined;


### PR DESCRIPTION
mcp-cli call used console.log() to emit tool results, which could return before all bytes were flushed when stdout was piped/captured by another process. In that mode, large responses could be truncated (observed at 64 KiB).

Switch to process.stdout.write() and wait for the drain event when backpressured. This ensures the command does not finish until the full output has been written, so captured stdout matches redirected file output.