### PR TITLE
fix(install): improve arm64 handling when release binaries are unavailable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,15 @@ cleanup() {
 }
 trap cleanup EXIT
 
+
+require_sudo() {
+    if ! command -v sudo &> /dev/null; then
+        echo -e "${RED}sudo is required for writing to $INSTALL_DIR but is not installed.${NC}"
+        echo "Set INSTALL_DIR to a writable path (e.g. INSTALL_DIR=$HOME/.local/bin) and retry."
+        exit 1
+    fi
+}
+
 # Detect OS and architecture
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
@@ -188,6 +197,7 @@ if [ ! -d "$INSTALL_DIR" ]; then
         mkdir -p "$INSTALL_DIR"
     else
         echo -e "${YELLOW}Requires sudo to create $INSTALL_DIR${NC}"
+        require_sudo
         sudo mkdir -p "$INSTALL_DIR"
     fi
 fi
@@ -198,6 +208,7 @@ if [ -w "$INSTALL_DIR" ]; then
     mv "$TMP_FILE" "$INSTALL_DIR/mcp-cli"
 else
     echo -e "${YELLOW}Requires sudo to install to $INSTALL_DIR${NC}"
+    require_sudo
     sudo mv "$TMP_FILE" "$INSTALL_DIR/mcp-cli"
 fi
 TMP_FILE=""  # Clear so cleanup doesn't try to delete

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Install script for mcp-cli
 # Usage: curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh | bash
+# Optional: set INSTALL_DIR to override the target install directory
 
 set -e
 

--- a/install.sh
+++ b/install.sh
@@ -169,6 +169,7 @@ if curl --retry 3 --connect-timeout 10 -fsSL "$CHECKSUM_URL" -o "$TMP_CHECKSUM" 
         fi
     else
         echo -e "${YELLOW}Warning: No checksum entry found for $BINARY; skipping verification.${NC}"
+        echo "Checksum source: $CHECKSUM_URL"
     fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -114,6 +114,14 @@ CHECKSUM_URL="https://github.com/$GITHUB_REPO/releases/latest/download/checksums
 # Dependency check
 if ! command -v curl &> /dev/null; then
     echo -e "${RED}curl is required but not installed.${NC}"
+    case "$OS" in
+        darwin)
+            echo "Install hint: brew install curl"
+            ;;
+        linux)
+            echo "Install hint: apt/yum/apk install curl (depending on your distro)"
+            ;;
+    esac
     echo "Please install curl and retry."
     exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -98,6 +98,7 @@ echo ""
 echo -e "  ${BOLD}Platform${NC}:  $OS/$ARCH"
 echo -e "  ${BOLD}Binary${NC}:    auto (${BINARY_CANDIDATES[*]})"
 echo -e "  ${BOLD}Location${NC}:  $INSTALL_DIR/mcp-cli"
+echo -e "  ${BOLD}Source${NC}:    https://github.com/$GITHUB_REPO/releases/latest"
 echo ""
 
 # Check for existing installation

--- a/install.sh
+++ b/install.sh
@@ -187,6 +187,7 @@ if curl --retry 3 --connect-timeout 10 -fsSL "$CHECKSUM_URL" -o "$TMP_CHECKSUM" 
                 exit 1
             fi
             echo -e "${GREEN}✓${NC} Checksum verified"
+            echo "Checksum source: $CHECKSUM_URL"
         fi
     else
         echo -e "${YELLOW}Warning: No checksum entry found for $BINARY; skipping verification.${NC}"

--- a/install.sh
+++ b/install.sh
@@ -112,6 +112,8 @@ if [ -z "$BINARY" ]; then
     exit 1
 fi
 
+echo -e "${GREEN}✓${NC} Selected binary: $BINARY"
+
 # Verify checksum (if available)
 TMP_CHECKSUM=$(mktemp)
 if curl -fsSL "$CHECKSUM_URL" -o "$TMP_CHECKSUM" 2>/dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -97,7 +97,7 @@ TMP_FILE=$(mktemp)
 BINARY=""
 for candidate in "${BINARY_CANDIDATES[@]}"; do
     DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/latest/download/$candidate"
-    if curl -fsSL "$DOWNLOAD_URL" -o "$TMP_FILE"; then
+    if curl --retry 3 --connect-timeout 10 -fsSL "$DOWNLOAD_URL" -o "$TMP_FILE"; then
         BINARY="$candidate"
         break
     fi
@@ -123,7 +123,7 @@ echo -e "${GREEN}✓${NC} Selected binary: $BINARY"
 
 # Verify checksum (if available)
 TMP_CHECKSUM=$(mktemp)
-if curl -fsSL "$CHECKSUM_URL" -o "$TMP_CHECKSUM" 2>/dev/null; then
+if curl --retry 3 --connect-timeout 10 -fsSL "$CHECKSUM_URL" -o "$TMP_CHECKSUM" 2>/dev/null; then
     # Extract checksum for our binary
     EXPECTED_CHECKSUM=$(awk -v binary="$BINARY" '$2 == binary { print $1 }' "$TMP_CHECKSUM")
     if [ -n "$EXPECTED_CHECKSUM" ]; then

--- a/install.sh
+++ b/install.sh
@@ -238,4 +238,5 @@ fi
 
 echo "Get started:"
 echo "  mcp-cli --help"
+echo "  mcp-cli --version"
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -251,3 +251,8 @@ echo "Get started:"
 echo "  mcp-cli --help"
 echo "  mcp-cli --version"
 echo ""
+if ! command -v mcp-cli &> /dev/null; then
+    echo -e "${YELLOW}Note:${NC} mcp-cli is not currently on PATH in this shell."
+    echo "Add $INSTALL_DIR to your PATH or open a new shell session."
+    echo ""
+fi

--- a/install.sh
+++ b/install.sh
@@ -115,7 +115,7 @@ if [ -z "$BINARY" ]; then
     echo "  cd mcp-cli"
     echo "  bun install"
     echo "  bun run build:linux-arm"
-    echo "  cp dist/mcp-cli-linux-arm64 ~/.local/bin/mcp-cli"
+    echo "  cp dist/mcp-cli-linux-arm64 "$INSTALL_DIR/mcp-cli""
     exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -32,15 +32,19 @@ ARCH=$(uname -m)
 case "$OS" in
     linux)
         case "$ARCH" in
-            x86_64) BINARY="mcp-cli-linux-x64" ;;
-            aarch64) BINARY="mcp-cli-linux-arm64" ;;
+            x86_64)
+                BINARY_CANDIDATES=("mcp-cli-linux-x64")
+                ;;
+            aarch64|arm64)
+                BINARY_CANDIDATES=("mcp-cli-linux-arm64" "mcp-cli-linux-aarch64")
+                ;;
             *) echo -e "${RED}Unsupported architecture: $ARCH${NC}"; exit 1 ;;
         esac
         ;;
     darwin)
         case "$ARCH" in
-            x86_64) BINARY="mcp-cli-darwin-x64" ;;
-            arm64) BINARY="mcp-cli-darwin-arm64" ;;
+            x86_64) BINARY_CANDIDATES=("mcp-cli-darwin-x64") ;;
+            arm64) BINARY_CANDIDATES=("mcp-cli-darwin-arm64") ;;
             *) echo -e "${RED}Unsupported architecture: $ARCH${NC}"; exit 1 ;;
         esac
         ;;
@@ -66,7 +70,7 @@ echo ""
 echo -e "${BOLD}Installing mcp-cli${NC}"
 echo ""
 echo -e "  ${BOLD}Platform${NC}:  $OS/$ARCH"
-echo -e "  ${BOLD}Binary${NC}:    $BINARY"
+echo -e "  ${BOLD}Binary${NC}:    ${BINARY_CANDIDATES[0]}"
 echo -e "  ${BOLD}Location${NC}:  $INSTALL_DIR/mcp-cli"
 echo ""
 
@@ -78,15 +82,33 @@ if command -v mcp-cli &> /dev/null; then
 fi
 
 # Get latest release URL
-DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/latest/download/$BINARY"
 CHECKSUM_URL="https://github.com/$GITHUB_REPO/releases/latest/download/checksums.txt"
 
-# Download binary
+# Download binary (with architecture fallback candidates)
 echo -e "${BLUE}Downloading...${NC}"
 TMP_FILE=$(mktemp)
-if ! curl -fsSL "$DOWNLOAD_URL" -o "$TMP_FILE"; then
-    echo -e "${RED}Failed to download binary. Check if releases exist at:${NC}"
-    echo "  https://github.com/$GITHUB_REPO/releases"
+BINARY=""
+for candidate in "${BINARY_CANDIDATES[@]}"; do
+    DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/latest/download/$candidate"
+    if curl -fsSL "$DOWNLOAD_URL" -o "$TMP_FILE"; then
+        BINARY="$candidate"
+        break
+    fi
+done
+
+if [ -z "$BINARY" ]; then
+    echo -e "${RED}Failed to download a binary for $OS/$ARCH.${NC}"
+    echo "Checked candidates: ${BINARY_CANDIDATES[*]}"
+    echo ""
+    echo "The latest release may not include this architecture yet."
+    echo "Release page: https://github.com/$GITHUB_REPO/releases"
+    echo ""
+    echo "Workaround (build locally with Bun):"
+    echo "  git clone https://github.com/$GITHUB_REPO.git"
+    echo "  cd mcp-cli"
+    echo "  bun install"
+    echo "  bun run build:linux-arm"
+    echo "  cp dist/mcp-cli-linux-arm64 ~/.local/bin/mcp-cli"
     exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,7 @@ if ! command -v curl &> /dev/null; then
 fi
 
 # Download binary (with architecture fallback candidates)
-echo -e "${BLUE}Downloading...${NC}"
+echo -e "${BLUE}Downloading release assets from GitHub...${NC}"
 TMP_FILE=$(mktemp)
 BINARY=""
 for candidate in "${BINARY_CANDIDATES[@]}"; do

--- a/install.sh
+++ b/install.sh
@@ -134,6 +134,7 @@ if [ -z "$BINARY" ]; then
     echo "  cd mcp-cli"
     echo "  bun install"
     echo "  $BUILD_CMD"
+    echo "  mkdir -p "$INSTALL_DIR""
     echo "  cp $BUILD_OUTPUT "$INSTALL_DIR/mcp-cli""
     exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -183,7 +183,12 @@ chmod +x "$TMP_FILE"
 # Create install directory if needed
 if [ ! -d "$INSTALL_DIR" ]; then
     echo -e "${BLUE}Creating $INSTALL_DIR...${NC}"
-    mkdir -p "$INSTALL_DIR"
+    if [ -w "$(dirname "$INSTALL_DIR")" ]; then
+        mkdir -p "$INSTALL_DIR"
+    else
+        echo -e "${YELLOW}Requires sudo to create $INSTALL_DIR${NC}"
+        sudo mkdir -p "$INSTALL_DIR"
+    fi
 fi
 
 # Install

--- a/install.sh
+++ b/install.sh
@@ -120,6 +120,10 @@ fi
 
 # Download binary (with architecture fallback candidates)
 echo -e "${BLUE}Downloading release assets from GitHub...${NC}"
+if [ ${#BINARY_CANDIDATES[@]} -gt 1 ]; then
+    echo "Candidate binaries: ${BINARY_CANDIDATES[*]}"
+fi
+
 TMP_FILE=$(mktemp)
 BINARY=""
 for candidate in "${BINARY_CANDIDATES[@]}"; do

--- a/install.sh
+++ b/install.sh
@@ -116,7 +116,7 @@ fi
 TMP_CHECKSUM=$(mktemp)
 if curl -fsSL "$CHECKSUM_URL" -o "$TMP_CHECKSUM" 2>/dev/null; then
     # Extract checksum for our binary
-    EXPECTED_CHECKSUM=$(grep "$BINARY" "$TMP_CHECKSUM" | awk '{print $1}')
+    EXPECTED_CHECKSUM=$(awk -v binary="$BINARY" '$2 == binary { print $1 }' "$TMP_CHECKSUM")
     if [ -n "$EXPECTED_CHECKSUM" ]; then
         echo -e "${BLUE}Verifying checksum...${NC}"
         # Calculate actual checksum

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ ARCH=$(uname -m)
 case "$OS" in
     linux)
         case "$ARCH" in
-            x86_64)
+            x86_64|amd64|x64)
                 BINARY_CANDIDATES=("mcp-cli-linux-x64")
                 ;;
             aarch64|arm64)
@@ -43,8 +43,8 @@ case "$OS" in
         ;;
     darwin)
         case "$ARCH" in
-            x86_64) BINARY_CANDIDATES=("mcp-cli-darwin-x64") ;;
-            arm64) BINARY_CANDIDATES=("mcp-cli-darwin-arm64") ;;
+            x86_64|amd64|x64) BINARY_CANDIDATES=("mcp-cli-darwin-x64") ;;
+            arm64|aarch64) BINARY_CANDIDATES=("mcp-cli-darwin-arm64") ;;
             *) echo -e "${RED}Unsupported architecture: $ARCH${NC}"; exit 1 ;;
         esac
         ;;

--- a/install.sh
+++ b/install.sh
@@ -127,6 +127,9 @@ if [ -z "$BINARY" ]; then
     echo "Release page: https://github.com/$GITHUB_REPO/releases"
     echo ""
     echo "Workaround (build locally with Bun):"
+    if ! command -v bun &> /dev/null; then
+        echo "  # Bun is not installed. Install it first: https://bun.sh"
+    fi
     echo "  git clone https://github.com/$GITHUB_REPO.git"
     echo "  cd mcp-cli"
     echo "  bun install"

--- a/install.sh
+++ b/install.sh
@@ -135,7 +135,11 @@ if [ -z "$BINARY" ]; then
     echo "  bun install"
     echo "  $BUILD_CMD"
     echo "  mkdir -p "$INSTALL_DIR""
-    echo "  cp $BUILD_OUTPUT "$INSTALL_DIR/mcp-cli""
+    if [ -w "$INSTALL_DIR" ]; then
+        echo "  cp $BUILD_OUTPUT "$INSTALL_DIR/mcp-cli""
+    else
+        echo "  sudo cp $BUILD_OUTPUT "$INSTALL_DIR/mcp-cli""
+    fi
     exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -205,6 +205,7 @@ TMP_FILE=""  # Clear so cleanup doesn't try to delete
 # Success message
 echo ""
 echo -e "${GREEN}✓ mcp-cli installed successfully!${NC}"
+echo "Installed to: $INSTALL_DIR/mcp-cli"
 echo ""
 
 # Check if in PATH and show version

--- a/install.sh
+++ b/install.sh
@@ -160,6 +160,7 @@ if [ -z "$BINARY" ]; then
 fi
 
 echo -e "${GREEN}✓${NC} Selected binary: $BINARY"
+echo "Download URL: $DOWNLOAD_URL"
 
 # Verify checksum (if available)
 TMP_CHECKSUM=$(mktemp)

--- a/install.sh
+++ b/install.sh
@@ -150,6 +150,7 @@ if [ -z "$BINARY" ]; then
     else
         echo "  sudo cp $BUILD_OUTPUT "$INSTALL_DIR/mcp-cli""
     fi
+    echo "  export PATH="$INSTALL_DIR:\$PATH""
     exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,22 @@ case "$OS" in
         ;;
 esac
 
+# Local build fallback command/output by platform
+case "$OS" in
+    linux)
+        BUILD_CMD="bun run build:linux-arm"
+        BUILD_OUTPUT="dist/mcp-cli-linux-arm64"
+        ;;
+    darwin)
+        BUILD_CMD="bun run build:macos-arm"
+        BUILD_OUTPUT="dist/mcp-cli-darwin-arm64"
+        ;;
+    *)
+        BUILD_CMD="bun run build"
+        BUILD_OUTPUT="dist/mcp-cli"
+        ;;
+esac
+
 # Installation directory - prefer ~/.local/bin (no sudo needed)
 if [ -z "${INSTALL_DIR:-}" ]; then
     if [ -w "/usr/local/bin" ]; then
@@ -114,8 +130,8 @@ if [ -z "$BINARY" ]; then
     echo "  git clone https://github.com/$GITHUB_REPO.git"
     echo "  cd mcp-cli"
     echo "  bun install"
-    echo "  bun run build:linux-arm"
-    echo "  cp dist/mcp-cli-linux-arm64 "$INSTALL_DIR/mcp-cli""
+    echo "  $BUILD_CMD"
+    echo "  cp $BUILD_OUTPUT "$INSTALL_DIR/mcp-cli""
     exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -84,6 +84,13 @@ fi
 # Get latest release URL
 CHECKSUM_URL="https://github.com/$GITHUB_REPO/releases/latest/download/checksums.txt"
 
+# Dependency check
+if ! command -v curl &> /dev/null; then
+    echo -e "${RED}curl is required but not installed.${NC}"
+    echo "Please install curl and retry."
+    exit 1
+fi
+
 # Download binary (with architecture fallback candidates)
 echo -e "${BLUE}Downloading...${NC}"
 TMP_FILE=$(mktemp)

--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,7 @@ echo ""
 echo -e "${BOLD}Installing mcp-cli${NC}"
 echo ""
 echo -e "  ${BOLD}Platform${NC}:  $OS/$ARCH"
-echo -e "  ${BOLD}Binary${NC}:    ${BINARY_CANDIDATES[0]}"
+echo -e "  ${BOLD}Binary${NC}:    auto (${BINARY_CANDIDATES[*]})"
 echo -e "  ${BOLD}Location${NC}:  $INSTALL_DIR/mcp-cli"
 echo ""
 

--- a/install.sh
+++ b/install.sh
@@ -163,6 +163,8 @@ if curl --retry 3 --connect-timeout 10 -fsSL "$CHECKSUM_URL" -o "$TMP_CHECKSUM" 
             fi
             echo -e "${GREEN}✓${NC} Checksum verified"
         fi
+    else
+        echo -e "${YELLOW}Warning: No checksum entry found for $BINARY; skipping verification.${NC}"
     fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -119,7 +119,7 @@ if ! command -v curl &> /dev/null; then
             echo "Install hint: brew install curl"
             ;;
         linux)
-            echo "Install hint: apt/yum/apk install curl (depending on your distro)"
+            echo "Install hint: use your distro package manager (e.g. apt, dnf/yum, pacman, apk) to install curl"
             ;;
     esac
     echo "Please install curl and retry."

--- a/install.sh
+++ b/install.sh
@@ -187,6 +187,9 @@ if curl --retry 3 --connect-timeout 10 -fsSL "$CHECKSUM_URL" -o "$TMP_CHECKSUM" 
         echo -e "${YELLOW}Warning: No checksum entry found for $BINARY; skipping verification.${NC}"
         echo "Checksum source: $CHECKSUM_URL"
     fi
+else
+    echo -e "${YELLOW}Warning: Could not download checksums.txt; skipping checksum verification.${NC}"
+    echo "Checksum source: $CHECKSUM_URL"
 fi
 
 # Make executable


### PR DESCRIPTION
## Summary
- replace single binary selection with candidate-based download attempts
- support both aarch64 and arm64 host arch names on Linux
- show explicit fallback guidance (build from source with Bun) when no arm64 asset exists

## Why
Issue #24 reports a 404 on Ubuntu arm64 during install. Current behavior fails with a generic message. This change keeps successful paths unchanged while providing clearer architecture fallback and actionable recovery steps for unsupported release artifacts.

## Validation
- bash -n install.sh
