### PR TITLE
docs(readme): document install script binary fallback behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > Common architecture aliases (for example `arm64`/`aarch64`, `x64`/`amd64`) are handled automatically by the installer.
 > You can override the install target with `INSTALL_DIR=/custom/path` before running the script.
 > The installer requires `curl` to download release assets.
+> If you prefer manual installation, download a release binary from GitHub Releases and place it on your `PATH` as `mcp-cli`.
 
 or 
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > If a selected asset has no checksum entry, the installer prints a warning and the checksum source URL for troubleshooting.
 > On successful asset resolution, the installer prints the selected binary name so you can confirm which artifact was used.
 > On successful installation, the script also prints the final install path (for example `/usr/local/bin/mcp-cli`).
+> After installation, run `mcp-cli --version` to verify the installed binary is on your `PATH`.
 > Common architecture aliases (for example `arm64`/`aarch64`, `x64`/`amd64`) are handled automatically by the installer.
 > You can override the install target with `INSTALL_DIR=/custom/path` before running the script.
 > The installer requires `curl` to download release assets.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > On successful asset resolution, the installer prints the selected binary name so you can confirm which artifact was used.
 > On successful installation, the script also prints the final install path (for example `/usr/local/bin/mcp-cli`).
 > After installation, run `mcp-cli --version` to verify the installed binary is on your `PATH`.
+> If the command is not found after install, add your install directory to `PATH` or start a new shell session.
 > Common architecture aliases (for example `arm64`/`aarch64`, `x64`/`amd64`) are handled automatically by the installer.
 > You can override the install target with `INSTALL_DIR=/custom/path` before running the script.
 > The installer requires `curl` to download release assets.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 
 > [!NOTE]
 > The installer auto-detects platform/architecture and tries compatible release binaries in order. If no matching asset exists, it prints local build fallback steps.
+> If your target install directory is not writable (for example `/usr/local/bin`), fallback commands may require `sudo`.
 
 or 
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > If your target install directory is not writable (for example `/usr/local/bin`), fallback commands may require `sudo`.
 > The installer also retries download requests and verifies checksums when entries are available in release assets.
 > If a selected asset has no checksum entry, the installer prints a warning and the checksum source URL for troubleshooting.
+> On successful asset resolution, the installer prints the selected binary name so you can confirm which artifact was used.
 > Common architecture aliases (for example `arm64`/`aarch64`, `x64`/`amd64`) are handled automatically by the installer.
 > You can override the install target with `INSTALL_DIR=/custom/path` before running the script.
 > The installer requires `curl` to download release assets.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > The installer auto-detects platform/architecture and tries compatible release binaries in order. If no matching asset exists, it prints local build fallback steps.
 > If your target install directory is not writable (for example `/usr/local/bin`), fallback commands may require `sudo`.
 > The installer also retries download requests and verifies checksums when entries are available in release assets.
+> If a selected asset has no checksum entry, the installer prints a warning and the checksum source URL for troubleshooting.
 > Common architecture aliases (for example `arm64`/`aarch64`, `x64`/`amd64`) are handled automatically by the installer.
 > You can override the install target with `INSTALL_DIR=/custom/path` before running the script.
 > The installer requires `curl` to download release assets.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > If the command is not found after install, add your install directory to `PATH` or start a new shell session.
 > Common architecture aliases (for example `arm64`/`aarch64`, `x64`/`amd64`) are handled automatically by the installer.
 > Local build fallback guidance is platform-aware (for example Linux arm64 vs macOS arm64 build outputs).
+> Fallback command examples quote install paths to avoid issues with spaces in directory names.
 > You can override the install target with `INSTALL_DIR=/custom/path` before running the script.
 > The installer requires `curl` to download release assets.
 > If you prefer manual installation, download a release binary from GitHub Releases and place it on your `PATH` as `mcp-cli`.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > If a selected asset has no checksum entry, the installer prints a warning and the checksum source URL for troubleshooting.
 > On successful asset resolution, the installer prints the selected binary name so you can confirm which artifact was used.
 > On successful installation, the script also prints the final install path (for example `/usr/local/bin/mcp-cli`).
+> The install banner includes the GitHub Releases source URL used for binary download.
 > After installation, run `mcp-cli --version` to verify the installed binary is on your `PATH`.
 > If the command is not found after install, add your install directory to `PATH` or start a new shell session.
 > Common architecture aliases (for example `arm64`/`aarch64`, `x64`/`amd64`) are handled automatically by the installer.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > The installer also retries download requests and verifies checksums when entries are available in release assets.
 > If a selected asset has no checksum entry, the installer prints a warning and the checksum source URL for troubleshooting.
 > On successful asset resolution, the installer prints the selected binary name so you can confirm which artifact was used.
+> On successful installation, the script also prints the final install path (for example `/usr/local/bin/mcp-cli`).
 > Common architecture aliases (for example `arm64`/`aarch64`, `x64`/`amd64`) are handled automatically by the installer.
 > You can override the install target with `INSTALL_DIR=/custom/path` before running the script.
 > The installer requires `curl` to download release assets.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > If your target install directory is not writable (for example `/usr/local/bin`), fallback commands may require `sudo`.
 > In environments without `sudo`, set `INSTALL_DIR` to a writable directory (for example `$HOME/.local/bin`).
 > The installer also retries download requests and verifies checksums when entries are available in release assets.
+> Download requests use retry + connect-timeout defaults to reduce transient network failures.
 > If a selected asset has no checksum entry, the installer prints a warning and the checksum source URL for troubleshooting.
 > If `checksums.txt` cannot be downloaded, the installer also warns and continues without checksum verification.
 > On successful asset resolution, the installer prints the selected binary name so you can confirm which artifact was used.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > [!NOTE]
 > The installer auto-detects platform/architecture and tries compatible release binaries in order. If no matching asset exists, it prints local build fallback steps.
 > If your target install directory is not writable (for example `/usr/local/bin`), fallback commands may require `sudo`.
+> In environments without `sudo`, set `INSTALL_DIR` to a writable directory (for example `$HOME/.local/bin`).
 > The installer also retries download requests and verifies checksums when entries are available in release assets.
 > If a selected asset has no checksum entry, the installer prints a warning and the checksum source URL for troubleshooting.
 > On successful asset resolution, the installer prints the selected binary name so you can confirm which artifact was used.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > After installation, run `mcp-cli --version` to verify the installed binary is on your `PATH`.
 > If the command is not found after install, add your install directory to `PATH` or start a new shell session.
 > Common architecture aliases (for example `arm64`/`aarch64`, `x64`/`amd64`) are handled automatically by the installer.
+> Local build fallback guidance is platform-aware (for example Linux arm64 vs macOS arm64 build outputs).
 > You can override the install target with `INSTALL_DIR=/custom/path` before running the script.
 > The installer requires `curl` to download release assets.
 > If you prefer manual installation, download a release binary from GitHub Releases and place it on your `PATH` as `mcp-cli`.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > In environments without `sudo`, set `INSTALL_DIR` to a writable directory (for example `$HOME/.local/bin`).
 > The installer also retries download requests and verifies checksums when entries are available in release assets.
 > If a selected asset has no checksum entry, the installer prints a warning and the checksum source URL for troubleshooting.
+> If `checksums.txt` cannot be downloaded, the installer also warns and continues without checksum verification.
 > On successful asset resolution, the installer prints the selected binary name so you can confirm which artifact was used.
 > On successful installation, the script also prints the final install path (for example `/usr/local/bin/mcp-cli`).
 > The install banner includes the GitHub Releases source URL used for binary download.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ A lightweight, Bun-based CLI for interacting with [MCP (Model Context Protocol)]
 - 🤖 **Agent-Optimized** - Designed for AI coding agents (Gemini CLI, Claude Code, etc.)
 - 🔌 **Universal** - Supports both stdio and HTTP MCP servers
 - ⚡ **Connection Pooling** - Lazy-spawn daemon keeps connections warm (60s idle timeout)
-- � **Tool Filtering** - Allow/disable specific tools per server via config
+- 🧰 **Tool Filtering** - Allow/disable specific tools per server via config
 - 📋 **Server Instructions** - Display MCP server instructions in output
-- �💡 **Actionable Errors** - Structured error messages with available servers and recovery suggestions
+- 💡 **Actionable Errors** - Structured error messages with available servers and recovery suggestions
 
 ![mcp-cli](./comparison.jpeg)
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > You can override the install target with `INSTALL_DIR=/custom/path` before running the script.
 > The installer requires `curl` to download release assets.
 > If `curl` is missing, the installer prints OS-specific install hints (for example Homebrew on macOS).
+> On Linux, the hint is distro-agnostic and references common package managers (apt, dnf/yum, pacman, apk).
 > If you prefer manual installation, download a release binary from GitHub Releases and place it on your `PATH` as `mcp-cli`.
 > After manual download, ensure the binary is executable (for example: `chmod +x mcp-cli`).
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > The installer also retries download requests and verifies checksums when entries are available in release assets.
 > Common architecture aliases (for example `arm64`/`aarch64`, `x64`/`amd64`) are handled automatically by the installer.
 > You can override the install target with `INSTALL_DIR=/custom/path` before running the script.
+> The installer requires `curl` to download release assets.
 
 or 
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > The installer also retries download requests and verifies checksums when entries are available in release assets.
 > Download requests use retry + connect-timeout defaults to reduce transient network failures.
 > If a selected asset has no checksum entry, the installer prints a warning and the checksum source URL for troubleshooting.
+> When checksum verification succeeds, the installer also prints the checksum source URL for traceability.
 > If `checksums.txt` cannot be downloaded, the installer also warns and continues without checksum verification.
 > On successful asset resolution, the installer prints the selected binary name so you can confirm which artifact was used.
 > The installer also prints the resolved download URL for the selected binary.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > [!NOTE]
 > The installer auto-detects platform/architecture and tries compatible release binaries in order. If no matching asset exists, it prints local build fallback steps.
 > If your target install directory is not writable (for example `/usr/local/bin`), fallback commands may require `sudo`.
+> The installer also retries download requests and verifies checksums when entries are available in release assets.
 
 or 
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > The installer auto-detects platform/architecture and tries compatible release binaries in order. If no matching asset exists, it prints local build fallback steps.
 > If your target install directory is not writable (for example `/usr/local/bin`), fallback commands may require `sudo`.
 > The installer also retries download requests and verifies checksums when entries are available in release assets.
+> Common architecture aliases (for example `arm64`/`aarch64`, `x64`/`amd64`) are handled automatically by the installer.
 
 or 
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > If `checksums.txt` cannot be downloaded, the installer also warns and continues without checksum verification.
 > On successful asset resolution, the installer prints the selected binary name so you can confirm which artifact was used.
 > The installer also prints the resolved download URL for the selected binary.
+> The install banner shows detected platform/architecture and target install location before download starts.
 > When multiple compatible assets are possible, the installer prints the candidate list before attempting downloads.
 > Candidate-list output appears only when more than one compatible asset is available for your platform/architecture.
 > On successful installation, the script also prints the final install path (for example `/usr/local/bin/mcp-cli`).

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > If your target install directory is not writable (for example `/usr/local/bin`), fallback commands may require `sudo`.
 > The installer also retries download requests and verifies checksums when entries are available in release assets.
 > Common architecture aliases (for example `arm64`/`aarch64`, `x64`/`amd64`) are handled automatically by the installer.
+> You can override the install target with `INSTALL_DIR=/custom/path` before running the script.
 
 or 
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > If a selected asset has no checksum entry, the installer prints a warning and the checksum source URL for troubleshooting.
 > If `checksums.txt` cannot be downloaded, the installer also warns and continues without checksum verification.
 > On successful asset resolution, the installer prints the selected binary name so you can confirm which artifact was used.
+> When multiple compatible assets are possible, the installer prints the candidate list before attempting downloads.
 > On successful installation, the script also prints the final install path (for example `/usr/local/bin/mcp-cli`).
 > The install banner includes the GitHub Releases source URL used for binary download.
 > After installation, run `mcp-cli --version` to verify the installed binary is on your `PATH`.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > Fallback command examples quote install paths to avoid issues with spaces in directory names.
 > You can override the install target with `INSTALL_DIR=/custom/path` before running the script.
 > The installer requires `curl` to download release assets.
+> If `curl` is missing, the installer prints OS-specific install hints (for example Homebrew on macOS).
 > If you prefer manual installation, download a release binary from GitHub Releases and place it on your `PATH` as `mcp-cli`.
 > After manual download, ensure the binary is executable (for example: `chmod +x mcp-cli`).
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ A lightweight, Bun-based CLI for interacting with [MCP (Model Context Protocol)]
 curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh | bash
 ```
 
+> [!NOTE]
+> The installer auto-detects platform/architecture and tries compatible release binaries in order. If no matching asset exists, it prints local build fallback steps.
+
 or 
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > If a selected asset has no checksum entry, the installer prints a warning and the checksum source URL for troubleshooting.
 > If `checksums.txt` cannot be downloaded, the installer also warns and continues without checksum verification.
 > On successful asset resolution, the installer prints the selected binary name so you can confirm which artifact was used.
+> The installer also prints the resolved download URL for the selected binary.
 > When multiple compatible assets are possible, the installer prints the candidate list before attempting downloads.
 > Candidate-list output appears only when more than one compatible asset is available for your platform/architecture.
 > On successful installation, the script also prints the final install path (for example `/usr/local/bin/mcp-cli`).

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > If `checksums.txt` cannot be downloaded, the installer also warns and continues without checksum verification.
 > On successful asset resolution, the installer prints the selected binary name so you can confirm which artifact was used.
 > When multiple compatible assets are possible, the installer prints the candidate list before attempting downloads.
+> Candidate-list output appears only when more than one compatible asset is available for your platform/architecture.
 > On successful installation, the script also prints the final install path (for example `/usr/local/bin/mcp-cli`).
 > The install banner includes the GitHub Releases source URL used for binary download.
 > After installation, run `mcp-cli --version` to verify the installed binary is on your `PATH`.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh 
 > You can override the install target with `INSTALL_DIR=/custom/path` before running the script.
 > The installer requires `curl` to download release assets.
 > If you prefer manual installation, download a release binary from GitHub Releases and place it on your `PATH` as `mcp-cli`.
+> After manual download, ensure the binary is executable (for example: `chmod +x mcp-cli`).
 
 or 
 


### PR DESCRIPTION
## Summary
- add a short note under install instructions
- clarify that install.sh auto-selects compatible assets per platform/arch
- mention local build fallback when no release asset matches

## Why
Recent installer improvements added candidate-based selection and fallback behavior. This note helps users understand expected install behavior and reduces confusion when a direct binary is unavailable.
