### PR TITLE
fix: scope env-var substitution to selected server

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -322,7 +322,7 @@ function isStrictEnvMode(): boolean {
  * By default (strict mode), throws an error when referenced env var is not set.
  * Set MCP_STRICT_ENV=false to warn instead of error.
  */
-function substituteEnvVars(value: string): string {
+function substituteEnvVars(value: string, scope?: string): string {
   const missingVars: string[] = [];
 
   const result = value.replace(/\$\{([^}]+)\}/g, (match, varName) => {
@@ -336,7 +336,8 @@ function substituteEnvVars(value: string): string {
 
   if (missingVars.length > 0) {
     const varList = missingVars.map((v) => `\${${v}}`).join(', ');
-    const message = `Missing environment variable${missingVars.length > 1 ? 's' : ''}: ${varList}`;
+    const scopeSuffix = scope ? ` (server: ${scope})` : '';
+    const message = `Missing environment variable${missingVars.length > 1 ? 's' : ''}: ${varList}${scopeSuffix}`;
 
     if (isStrictEnvMode()) {
       throw new Error(
@@ -359,17 +360,17 @@ function substituteEnvVars(value: string): string {
 /**
  * Recursively substitute environment variables in an object
  */
-function substituteEnvVarsInObject<T>(obj: T): T {
+function substituteEnvVarsInObject<T>(obj: T, scope?: string): T {
   if (typeof obj === 'string') {
-    return substituteEnvVars(obj) as T;
+    return substituteEnvVars(obj, scope) as T;
   }
   if (Array.isArray(obj)) {
-    return obj.map(substituteEnvVarsInObject) as T;
+    return obj.map((item) => substituteEnvVarsInObject(item, scope)) as T;
   }
   if (obj && typeof obj === 'object') {
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj)) {
-      result[key] = substituteEnvVarsInObject(value);
+      result[key] = substituteEnvVarsInObject(value, scope);
     }
     return result as T;
   }
@@ -496,9 +497,6 @@ export async function loadConfig(
     }
   }
 
-  // Substitute environment variables
-  config = substituteEnvVarsInObject(config);
-
   return config;
 }
 
@@ -514,7 +512,7 @@ export function getServerConfig(
     const available = Object.keys(config.mcpServers);
     throw new Error(formatCliError(serverNotFoundError(serverName, available)));
   }
-  return server;
+  return substituteEnvVarsInObject(server, serverName);
 }
 
 /**

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -61,7 +61,7 @@ describe('config', () => {
       await expect(loadConfig(configPath)).rejects.toThrow('mcpServers');
     });
 
-    test('substitutes environment variables', async () => {
+    test('keeps env placeholders in loaded config', async () => {
       process.env.TEST_MCP_TOKEN = 'secret123';
 
       const configPath = join(tempDir, 'env_config.json');
@@ -79,37 +79,12 @@ describe('config', () => {
 
       const config = await loadConfig(configPath);
       const server = config.mcpServers.test as any;
-      expect(server.headers.Authorization).toBe('Bearer secret123');
+      expect(server.headers.Authorization).toBe('Bearer ${TEST_MCP_TOKEN}');
 
       delete process.env.TEST_MCP_TOKEN;
     });
 
-    test('handles missing env vars gracefully with MCP_STRICT_ENV=false', async () => {
-      // Set non-strict mode to allow missing env vars with warning
-      process.env.MCP_STRICT_ENV = 'false';
-
-      const configPath = join(tempDir, 'missing_env.json');
-      await writeFile(
-        configPath,
-        JSON.stringify({
-          mcpServers: {
-            test: {
-              command: 'echo',
-              env: { TOKEN: '${NONEXISTENT_VAR}' },
-            },
-          },
-        })
-      );
-
-      const config = await loadConfig(configPath);
-      const server = config.mcpServers.test as any;
-      expect(server.env.TOKEN).toBe('');
-
-      delete process.env.MCP_STRICT_ENV;
-    });
-
-    test('throws error on missing env vars in strict mode (default)', async () => {
-      // Ensure strict mode is enabled (default)
+    test('does not validate missing env vars during load', async () => {
       delete process.env.MCP_STRICT_ENV;
 
       const configPath = join(tempDir, 'missing_env_strict.json');
@@ -125,7 +100,7 @@ describe('config', () => {
         })
       );
 
-      await expect(loadConfig(configPath)).rejects.toThrow('MISSING_ENV_VAR');
+      await expect(loadConfig(configPath)).resolves.toBeDefined();
     });
 
     test('throws error on empty server config', async () => {
@@ -190,6 +165,46 @@ describe('config', () => {
       const config = await loadConfig(configPath);
       const server = getServerConfig(config, 'server1');
       expect((server as any).command).toBe('cmd1');
+    });
+
+    test('substitutes env vars only for selected server', async () => {
+      process.env.MCP_STRICT_ENV = 'false';
+      process.env.SERVER1_TOKEN = 'abc123';
+
+      const configPath = join(tempDir, 'scoped_env.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            server1: { command: 'cmd1', env: { TOKEN: '${SERVER1_TOKEN}' } },
+            server2: { command: 'cmd2', env: { TOKEN: '${MISSING_TOKEN}' } },
+          },
+        })
+      );
+
+      const config = await loadConfig(configPath);
+      const server = getServerConfig(config, 'server1') as any;
+      expect(server.env.TOKEN).toBe('abc123');
+
+      delete process.env.SERVER1_TOKEN;
+      delete process.env.MCP_STRICT_ENV;
+    });
+
+    test('throws on missing env vars for selected server in strict mode', async () => {
+      delete process.env.MCP_STRICT_ENV;
+
+      const configPath = join(tempDir, 'strict_env_server.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            target: { command: 'cmd', env: { TOKEN: '${MISSING_TARGET_TOKEN}' } },
+          },
+        })
+      );
+
+      const config = await loadConfig(configPath);
+      expect(() => getServerConfig(config, 'target')).toThrow('MISSING_ENV_VAR');
     });
 
     test('throws on unknown server', async () => {


### PR DESCRIPTION
## Summary
- stop substituting env vars for every server during loadConfig
- apply env substitution only when getServerConfig() resolves the selected server
- include server name in missing-env warning/error context
- update config tests to verify load-time behavior and selected-server substitution

## Why
This addresses #20 where warnings for missing env vars were shown for unrelated servers. With this change, users only see env-var warnings/errors for the server they are actually querying.

Closes #20
