### PR TITLE
feat(config): add JSON schema for mcp_servers.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,10 +276,14 @@ fi
 
 ### Config File Format
 
-The CLI uses `mcp_servers.json`, compatible with Claude Desktop, Gemini or VS Code:
+The CLI uses `mcp_servers.json`, compatible with Claude Desktop, Gemini or VS Code.
+
+A JSON Schema is available at [`mcp_servers.schema.json`](./mcp_servers.schema.json).
+You can reference it at the top of your config for IDE validation/autocomplete:
 
 ```json
 {
+  "$schema": "https://raw.githubusercontent.com/philschmid/mcp-cli/main/mcp_servers.schema.json",
   "mcpServers": {
     "local-server": {
       "command": "node",

--- a/mcp_servers.schema.json
+++ b/mcp_servers.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/philschmid/mcp-cli/main/mcp_servers.schema.json",
+  "title": "mcp-cli server configuration",
+  "type": "object",
+  "required": ["mcpServers"],
+  "additionalProperties": false,
+  "properties": {
+    "mcpServers": {
+      "type": "object",
+      "description": "Map of server name to MCP server configuration",
+      "additionalProperties": {
+        "$ref": "#/$defs/server"
+      }
+    }
+  },
+  "$defs": {
+    "base": {
+      "type": "object",
+      "properties": {
+        "allowedTools": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Glob patterns of allowed tools"
+        },
+        "disabledTools": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Glob patterns of disabled tools (takes precedence over allowedTools)"
+        }
+      }
+    },
+    "stdioServer": {
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "type": "object",
+          "required": ["command"],
+          "additionalProperties": false,
+          "properties": {
+            "command": { "type": "string" },
+            "args": { "type": "array", "items": { "type": "string" } },
+            "env": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "cwd": { "type": "string" },
+            "allowedTools": { "$ref": "#/$defs/base/properties/allowedTools" },
+            "disabledTools": { "$ref": "#/$defs/base/properties/disabledTools" }
+          }
+        }
+      ]
+    },
+    "httpServer": {
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "type": "object",
+          "required": ["url"],
+          "additionalProperties": false,
+          "properties": {
+            "url": { "type": "string", "format": "uri" },
+            "headers": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "timeout": { "type": "number", "minimum": 0 },
+            "allowedTools": { "$ref": "#/$defs/base/properties/allowedTools" },
+            "disabledTools": { "$ref": "#/$defs/base/properties/disabledTools" }
+          }
+        }
+      ]
+    },
+    "server": {
+      "oneOf": [
+        {
+          "allOf": [
+            { "$ref": "#/$defs/stdioServer" },
+            { "not": { "required": ["url"] } }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/httpServer" },
+            { "not": { "required": ["command"] } }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `mcp_servers.schema.json` to describe the `mcpServers` config format
- cover both stdio (`command`) and HTTP (`url`) server types
- include tool-filtering fields (`allowedTools`, `disabledTools`) and server-specific fields (`args`, `env`, `cwd`, `headers`, `timeout`)
- document schema usage in README with `$schema` example for IDE validation

## Why
Issue #32 asks for a schema file to validate configuration format. This PR provides a first-party schema that editors can use for autocomplete and validation.

Closes #32
