### PR TITLE
fix: only stream server stderr in debug/opt-in mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,8 @@ The CLI searches for configuration in this order:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `MCP_CONFIG_PATH` | Path to config file | (none) |
-| `MCP_DEBUG` | Enable debug output | `false` |
+| `MCP_DEBUG` | Enable debug output (includes live server stderr) | `false` |
+| `MCP_STDERR` | Stream server stderr during successful runs (`1` to enable) | `false` |
 | `MCP_TIMEOUT` | Request timeout (seconds) | `1800` (30 min) |
 | `MCP_CONCURRENCY` | Servers processed in parallel (not a limit on total) | `5` |
 | `MCP_MAX_RETRIES` | Retry attempts for transient errors (0 = disable) | `3` |

--- a/src/client.ts
+++ b/src/client.ts
@@ -243,15 +243,18 @@ export async function connectToServer(
     } else {
       transport = createStdioTransport(config);
 
-      // Capture stderr for debugging - attach BEFORE connect
-      // Always stream stderr immediately so auth prompts are visible
+      // Capture stderr for enhanced error messages.
+      // Stream live stderr only in debug mode (or when explicitly enabled).
       const stderrStream = transport.stderr;
+      const shouldStreamStderr =
+        process.env.MCP_DEBUG || process.env.MCP_STDERR === '1';
       if (stderrStream) {
         stderrStream.on('data', (chunk: Buffer) => {
           const text = chunk.toString();
           stderrChunks.push(text);
-          // Always stream stderr immediately so users can see auth prompts
-          process.stderr.write(`[${serverName}] ${text}`);
+          if (shouldStreamStderr) {
+            process.stderr.write(`[${serverName}] ${text}`);
+          }
         });
       }
     }
@@ -266,16 +269,6 @@ export async function connectToServer(
         err.message = `${err.message}\n\nServer stderr:\n${stderrOutput}`;
       }
       throw error;
-    }
-
-    // For successful connections, forward stderr to console
-    if (!isHttpServer(config)) {
-      const stderrStream = (transport as StdioClientTransport).stderr;
-      if (stderrStream) {
-        stderrStream.on('data', (chunk: Buffer) => {
-          process.stderr.write(chunk);
-        });
-      }
     }
 
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,6 +383,8 @@ Examples:
   cat input.json | mcp-cli call server tool      # Read from stdin (no '-' needed)
 
 Environment Variables:
+  MCP_DEBUG=1            Enable debug logs (also streams server stderr)
+  MCP_STDERR=1           Stream server stderr during successful runs
   MCP_NO_DAEMON=1        Disable connection caching (force fresh connections)
   MCP_DAEMON_TIMEOUT=N   Set daemon idle timeout in seconds (default: 60)
 


### PR DESCRIPTION
## Summary
- stop streaming MCP server stderr by default during successful runs
- keep capturing stderr internally so failed connections still include useful diagnostics
- add opt-in live stderr streaming via MCP_STDERR=1 (and MCP_DEBUG still enables it)
- document the new env var in README

## Why
This addresses noisy stderr output during normal agent usage and aligns with issue #17 request to show stderr only in debug/verbose contexts.

Closes #17
