### PR TITLE
fix(daemon): support chunked IPC responses to avoid pipe truncation

### DIFF
--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -56,6 +56,25 @@ async function sendRequest(
   request: DaemonRequest,
 ): Promise<DaemonResponse> {
   return new Promise((resolve, reject) => {
+    let settled = false;
+    let buffer = '';
+
+    const settleResolve = (response: DaemonResponse) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeoutId);
+        resolve(response);
+      }
+    };
+
+    const settleReject = (error: Error) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeoutId);
+        reject(error);
+      }
+    };
+
     const socket = Bun.connect({
       unix: socketPath,
       socket: {
@@ -63,30 +82,44 @@ async function sendRequest(
           socket.write(JSON.stringify(request));
         },
         data(socket, data) {
+          buffer += data.toString();
+          const newlineIndex = buffer.indexOf('
+');
+          if (newlineIndex === -1) {
+            return;
+          }
+
+          const raw = buffer.slice(0, newlineIndex).trim();
           try {
-            const response = JSON.parse(data.toString().trim());
+            const response = JSON.parse(raw) as DaemonResponse;
             socket.end();
-            resolve(response);
-          } catch (err) {
+            settleResolve(response);
+          } catch {
             socket.end();
-            reject(new Error('Invalid response from daemon'));
+            settleReject(new Error('Invalid response from daemon'));
           }
         },
         error(socket, error) {
-          reject(error);
+          settleReject(error instanceof Error ? error : new Error(String(error)));
         },
         close() {
           // Connection closed
         },
         connectError(socket, error) {
-          reject(error);
+          settleReject(error instanceof Error ? error : new Error(String(error)));
         },
       },
     });
 
-    // Timeout after 5 seconds (fast fallback to direct connection)
-    setTimeout(() => {
-      reject(new Error('Daemon request timeout'));
+    const timeoutId = setTimeout(() => {
+      if (!settled) {
+        try {
+          socket.end();
+        } catch {
+          // ignore
+        }
+        settleReject(new Error('Daemon request timeout'));
+      }
     }, 5000);
   });
 }


### PR DESCRIPTION
## Summary
- fix daemon client IPC response parsing to handle chunked socket data correctly
- accumulate incoming bytes until newline-delimited JSON frame is complete
- avoid parsing partial frames (which can silently cut large payloads)
- make timeout/error handling single-settle safe to avoid duplicate resolve/reject races

## Why
Issue #23 reports output truncation at exactly 65536 bytes when piping. The daemon IPC client currently parses each socket data event as if it were a complete JSON response. On large responses, data may arrive in multiple chunks, causing partial-frame parsing and truncated downstream output.

This patch aligns the client with daemon framing (JSON lines) and only parses after a full frame is received.

Closes #23
