### PR TITLE
docs(help): mention MCP_STDERR in CLI usage output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -385,6 +385,7 @@ Examples:
 Environment Variables:
   MCP_NO_DAEMON=1        Disable connection caching (force fresh connections)
   MCP_DAEMON_TIMEOUT=N   Set daemon idle timeout in seconds (default: 60)
+  MCP_STDERR=1           Stream server stderr during successful runs
 
 Config File:
   The CLI looks for mcp_servers.json in:


### PR DESCRIPTION
## Summary
- add MCP_STDERR env var to the built-in CLI help text
- keep help output aligned with recent stderr gating behavior

## Why
MCP_STDERR is documented in README and supported in code, but was missing in the `mcp-cli --help` environment variable section. This closes that docs gap.
