### PR TITLE
docs(help): include MCP_DEBUG and MCP_STDERR in env vars list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -383,6 +383,8 @@ Examples:
   cat input.json | mcp-cli call server tool      # Read from stdin (no '-' needed)
 
 Environment Variables:
+  MCP_DEBUG=1            Enable debug logs (includes live server stderr)
+  MCP_STDERR=1           Stream server stderr during successful runs
   MCP_NO_DAEMON=1        Disable connection caching (force fresh connections)
   MCP_DAEMON_TIMEOUT=N   Set daemon idle timeout in seconds (default: 60)
 


### PR DESCRIPTION
## Summary\n- add MCP_DEBUG and MCP_STDERR to the CLI help environment variable section\n- keep  aligned with current stderr/debug behavior\n\n## Why\nUsers should be able to discover stderr/debug controls directly from CLI help without opening README.