### PR TITLE
fix: scope env substitution to targeted server

### DIFF
--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -108,15 +108,6 @@ async function parseArgs(
  * Execute the call command
  */
 export async function callCommand(options: CallOptions): Promise<void> {
-  let config: McpServersConfig;
-
-  try {
-    config = await loadConfig(options.configPath);
-  } catch (error) {
-    console.error((error as Error).message);
-    process.exit(ErrorCode.CLIENT_ERROR);
-  }
-
   let serverName: string;
   let toolName: string;
 
@@ -124,6 +115,17 @@ export async function callCommand(options: CallOptions): Promise<void> {
     const parsed = parseTarget(options.target);
     serverName = parsed.server;
     toolName = parsed.tool;
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exit(ErrorCode.CLIENT_ERROR);
+  }
+
+  let config: McpServersConfig;
+
+  try {
+    config = await loadConfig(options.configPath, {
+      substituteServers: [serverName],
+    });
   } catch (error) {
     console.error((error as Error).message);
     process.exit(ErrorCode.CLIENT_ERROR);

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -38,16 +38,18 @@ function parseTarget(target: string): { server: string; tool?: string } {
  * Execute the info command
  */
 export async function infoCommand(options: InfoOptions): Promise<void> {
+  const { server: serverName, tool: toolName } = parseTarget(options.target);
+
   let config: McpServersConfig;
 
   try {
-    config = await loadConfig(options.configPath);
+    config = await loadConfig(options.configPath, {
+      substituteServers: [serverName],
+    });
   } catch (error) {
     console.error((error as Error).message);
     process.exit(ErrorCode.CLIENT_ERROR);
   }
-
-  const { server: serverName, tool: toolName } = parseTarget(options.target);
 
   let serverConfig: ServerConfig;
   try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,14 @@ export interface McpServersConfig {
   mcpServers: Record<string, ServerConfig>;
 }
 
+export interface LoadConfigOptions {
+  /**
+   * Only substitute environment variables for these servers.
+   * Other server configs are returned untouched and evaluated lazily by callers.
+   */
+  substituteServers?: string[];
+}
+
 // ============================================================================
 // Tool Filtering
 // ============================================================================
@@ -398,6 +406,7 @@ function getDefaultConfigPaths(): string[] {
  */
 export async function loadConfig(
   explicitPath?: string,
+  options?: LoadConfigOptions,
 ): Promise<McpServersConfig> {
   let configPath: string | undefined;
 
@@ -496,8 +505,24 @@ export async function loadConfig(
     }
   }
 
-  // Substitute environment variables
-  config = substituteEnvVarsInObject(config);
+  // Substitute environment variables lazily for the requested server(s).
+  // This avoids unrelated servers with missing env vars polluting targeted commands
+  // such as `info <server>` or `call <server>/<tool>`.
+  const substituteServers = new Set(
+    options?.substituteServers ?? Object.keys(config.mcpServers),
+  );
+
+  config = {
+    ...config,
+    mcpServers: Object.fromEntries(
+      Object.entries(config.mcpServers).map(([serverName, serverConfig]) => [
+        serverName,
+        substituteServers.has(serverName)
+          ? substituteEnvVarsInObject(serverConfig)
+          : serverConfig,
+      ]),
+    ),
+  };
 
   return config;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,6 +383,8 @@ Examples:
   cat input.json | mcp-cli call server tool      # Read from stdin (no '-' needed)
 
 Environment Variables:
+  MCP_DEBUG=1            Enable debug logs (includes live server stderr)
+  MCP_STDERR=1           Stream server stderr during successful runs
   MCP_NO_DAEMON=1        Disable connection caching (force fresh connections)
   MCP_DAEMON_TIMEOUT=N   Set daemon idle timeout in seconds (default: 60)
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -84,6 +84,35 @@ describe('config', () => {
       delete process.env.TEST_MCP_TOKEN;
     });
 
+    test('only substitutes env vars for scoped servers', async () => {
+      delete process.env.MCP_STRICT_ENV;
+      delete process.env.UNRELATED_SECRET;
+
+      const configPath = join(tempDir, 'scoped_env_config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            chrome: {
+              command: 'echo',
+              args: ['ok'],
+            },
+            github: {
+              command: 'echo',
+              env: { TOKEN: '${UNRELATED_SECRET}' },
+            },
+          },
+        })
+      );
+
+      const config = await loadConfig(configPath, {
+        substituteServers: ['chrome'],
+      });
+
+      expect((config.mcpServers.chrome as any).args).toEqual(['ok']);
+      expect((config.mcpServers.github as any).env.TOKEN).toBe('${UNRELATED_SECRET}');
+    });
+
     test('handles missing env vars gracefully with MCP_STRICT_ENV=false', async () => {
       // Set non-strict mode to allow missing env vars with warning
       process.env.MCP_STRICT_ENV = 'false';


### PR DESCRIPTION
$## Summary\n- only substitute environment variables for the server requested by `info <server>` and `call <server>/<tool>`\n- keep other server configs untouched so unrelated missing env vars do not block or warn on targeted commands\n- add a regression test covering scoped substitution\n\n## Testing\n- bun test tests/config.test.ts\n- npx tsc --noEmit\n- npx @biomejs/biome check src/\n\nFixes #20