### PR TITLE
fix: gate live stderr streaming behind env vars

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -91,6 +91,15 @@ function getRetryConfig(): RetryConfig {
 }
 
 /**
+ * Check whether server stderr should be streamed live to the terminal.
+ * Stderr is always captured for connection error reporting, but live streaming
+ * is opt-in to avoid noisy output during successful runs.
+ */
+export function shouldStreamServerStderr(): boolean {
+  return process.env.MCP_DEBUG === '1' || process.env.MCP_STDERR === '1';
+}
+
+/**
  * Check if an error is transient and worth retrying
  * Uses error codes when available, falls back to message matching
  */
@@ -243,15 +252,16 @@ export async function connectToServer(
     } else {
       transport = createStdioTransport(config);
 
-      // Capture stderr for debugging - attach BEFORE connect
-      // Always stream stderr immediately so auth prompts are visible
+      // Capture stderr before connect so we can enrich connection errors.
+      // Live stderr streaming stays opt-in via MCP_DEBUG=1 or MCP_STDERR=1.
       const stderrStream = transport.stderr;
       if (stderrStream) {
         stderrStream.on('data', (chunk: Buffer) => {
           const text = chunk.toString();
           stderrChunks.push(text);
-          // Always stream stderr immediately so users can see auth prompts
-          process.stderr.write(`[${serverName}] ${text}`);
+          if (shouldStreamServerStderr()) {
+            process.stderr.write(`[${serverName}] ${text}`);
+          }
         });
       }
     }
@@ -266,16 +276,6 @@ export async function connectToServer(
         err.message = `${err.message}\n\nServer stderr:\n${stderrOutput}`;
       }
       throw error;
-    }
-
-    // For successful connections, forward stderr to console
-    if (!isHttpServer(config)) {
-      const stderrStream = (transport as StdioClientTransport).stderr;
-      if (stderrStream) {
-        stderrStream.on('data', (chunk: Buffer) => {
-          process.stderr.write(chunk);
-        });
-      }
     }
 
     return {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -15,6 +15,7 @@ import {
   isTransientError,
   getTimeoutMs,
   getConcurrencyLimit,
+  shouldStreamServerStderr,
 } from '../src/client';
 
 describe('client', () => {
@@ -54,6 +55,43 @@ describe('client', () => {
       };
 
       expect(isStdioServer(minimalStdio)).toBe(true);
+    });
+  });
+
+  describe('shouldStreamServerStderr', () => {
+    const originalDebug = process.env.MCP_DEBUG;
+    const originalStderr = process.env.MCP_STDERR;
+
+    afterEach(() => {
+      if (originalDebug !== undefined) {
+        process.env.MCP_DEBUG = originalDebug;
+      } else {
+        delete process.env.MCP_DEBUG;
+      }
+
+      if (originalStderr !== undefined) {
+        process.env.MCP_STDERR = originalStderr;
+      } else {
+        delete process.env.MCP_STDERR;
+      }
+    });
+
+    test('returns false by default', () => {
+      delete process.env.MCP_DEBUG;
+      delete process.env.MCP_STDERR;
+      expect(shouldStreamServerStderr()).toBe(false);
+    });
+
+    test('returns true when MCP_DEBUG=1', () => {
+      process.env.MCP_DEBUG = '1';
+      delete process.env.MCP_STDERR;
+      expect(shouldStreamServerStderr()).toBe(true);
+    });
+
+    test('returns true when MCP_STDERR=1', () => {
+      delete process.env.MCP_DEBUG;
+      process.env.MCP_STDERR = '1';
+      expect(shouldStreamServerStderr()).toBe(true);
     });
   });
 


### PR DESCRIPTION
$## Summary\n- stop streaming MCP server stderr during successful runs unless `MCP_DEBUG=1` or `MCP_STDERR=1` is set\n- keep stderr capture in place for connection error reporting\n- add regression tests for the new stderr streaming gate\n\n## Testing\n- bun test tests/client.test.ts\n- npx tsc --noEmit\n- npx @biomejs/biome check src/\n\nCloses #17