### PR TITLE
fix: publish linux arm64 release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
       
       - name: Build Linux x64
         run: bun build --compile --minify --target=bun-linux-x64 src/index.ts --outfile dist/mcp-cli-linux-x64
+
+      - name: Build Linux ARM64
+        run: bun build --compile --minify --target=bun-linux-arm64 src/index.ts --outfile dist/mcp-cli-linux-arm64
       
       - name: Build macOS x64
         run: bun build --compile --minify --target=bun-darwin-x64 src/index.ts --outfile dist/mcp-cli-darwin-x64
@@ -95,6 +98,7 @@ jobs:
           generate_release_notes: true
           files: |
             dist/mcp-cli-linux-x64
+            dist/mcp-cli-linux-arm64
             dist/mcp-cli-darwin-x64
             dist/mcp-cli-darwin-arm64
             dist/checksums.txt


### PR DESCRIPTION
## Summary
- add a Linux ARM64 build step to the release workflow
- upload the resulting `mcp-cli-linux-arm64` binary as a release asset

## Why
Issue #24 reports that the install script selects `mcp-cli-linux-arm64` on Ubuntu arm64, but the release workflow never publishes that artifact. That means the installer is guaranteed to 404 for Linux arm64 users even though the project already has a matching build target in `package.json`.

## Validation
- `git diff --check`
