### PR TITLE
fix: silence server stderr unless debug is enabled

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -250,8 +250,9 @@ export async function connectToServer(
         stderrStream.on('data', (chunk: Buffer) => {
           const text = chunk.toString();
           stderrChunks.push(text);
-          // Always stream stderr immediately so users can see auth prompts
-          process.stderr.write(`[${serverName}] ${text}`);
+          if (process.env.MCP_DEBUG) {
+            process.stderr.write(`[${serverName}] ${text}`);
+          }
         });
       }
     }
@@ -266,16 +267,6 @@ export async function connectToServer(
         err.message = `${err.message}\n\nServer stderr:\n${stderrOutput}`;
       }
       throw error;
-    }
-
-    // For successful connections, forward stderr to console
-    if (!isHttpServer(config)) {
-      const stderrStream = (transport as StdioClientTransport).stderr;
-      if (stderrStream) {
-        stderrStream.on('data', (chunk: Buffer) => {
-          process.stderr.write(chunk);
-        });
-      }
     }
 
     return {

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -52,6 +52,30 @@ describe('CLI Integration Tests', () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
+  async function createNoisyServerConfig(name: string): Promise<string> {
+    const serverPath = join(tempDir, `${name}.js`);
+    await writeFile(
+      serverPath,
+      `process.stderr.write("startup noise\\n");
+process.exit(1);
+`
+    );
+
+    const noisyConfigPath = join(tempDir, `${name}.json`);
+    await writeFile(
+      noisyConfigPath,
+      JSON.stringify({
+        mcpServers: {
+          noisy: {
+            command: 'node',
+            args: [serverPath],
+          },
+        },
+      })
+    );
+    return noisyConfigPath;
+  }
+
   // Helper to run CLI commands
   async function runCli(
     args: string[]
@@ -75,6 +99,31 @@ describe('CLI Integration Tests', () => {
       };
     }
   }
+
+  describe('server stderr forwarding', () => {
+    test('does not stream server stderr immediately by default', async () => {
+      const noisyConfigPath = await createNoisyServerConfig('noisy-default');
+      const cliPath = join(import.meta.dir, '..', '..', 'src', 'index.ts');
+      const result = await $`MCP_NO_DAEMON=1 MCP_MAX_RETRIES=0 bun run ${cliPath} -c ${noisyConfigPath} info noisy`.nothrow();
+      const stderr = result.stderr.toString();
+
+      expect(stderr).toContain('Server stderr:');
+      expect(stderr).toContain('startup noise');
+      expect(stderr).not.toContain('[noisy] startup noise');
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    test('streams server stderr immediately when MCP_DEBUG is enabled', async () => {
+      const noisyConfigPath = await createNoisyServerConfig('noisy-debug');
+      const cliPath = join(import.meta.dir, '..', '..', 'src', 'index.ts');
+      const result = await $`MCP_NO_DAEMON=1 MCP_MAX_RETRIES=0 MCP_DEBUG=1 bun run ${cliPath} -c ${noisyConfigPath} info noisy`.nothrow();
+      const stderr = result.stderr.toString();
+
+      expect(stderr).toContain('[noisy] startup noise');
+      expect(stderr).toContain('Server stderr:');
+      expect(result.exitCode).not.toBe(0);
+    });
+  });
 
   describe('--help', () => {
     test('shows help message', async () => {
@@ -316,6 +365,30 @@ describe('HTTP Transport Integration Tests', () => {
   afterAll(async () => {
     await rm(tempDir, { recursive: true, force: true });
   });
+
+  async function createNoisyServerConfig(name: string): Promise<string> {
+    const serverPath = join(tempDir, `${name}.js`);
+    await writeFile(
+      serverPath,
+      `process.stderr.write("startup noise\\n");
+process.exit(1);
+`
+    );
+
+    const noisyConfigPath = join(tempDir, `${name}.json`);
+    await writeFile(
+      noisyConfigPath,
+      JSON.stringify({
+        mcpServers: {
+          noisy: {
+            command: 'node',
+            args: [serverPath],
+          },
+        },
+      })
+    );
+    return noisyConfigPath;
+  }
 
   // Helper to run CLI commands with HTTP config
   async function runCli(


### PR DESCRIPTION
## Summary
- stop streaming MCP server stderr to the terminal during normal successful/direct connection attempts
- keep capturing stderr so connection failures still include `Server stderr:` details
- add integration coverage for default-silent vs `MCP_DEBUG=1` stderr behavior

## Why
Fixes #17. Right now `mcp-cli` forwards stdio server stderr unconditionally, which is useful for debugging but noisy for agents and scripted callers. This change keeps the diagnostics for failures while making the default successful path quiet unless debug mode is explicitly enabled.

## Validation
- `bun test tests/integration/cli.test.ts -t 'server stderr forwarding'`
- `bun test tests/client.test.ts`
- `git diff --check`
