### PR TITLE
fix: avoid truncating piped call output

### DIFF
--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -163,7 +163,7 @@ export async function callCommand(options: CallOptions): Promise<void> {
 
     // Extract text content from MCP response for CLI-friendly output
     // Uses formatToolResult which extracts text from MCP content array
-    console.log(formatToolResult(result));
+    process.stdout.write(formatToolResult(result) + "\n");
   } catch (error) {
     // Try to get available tools for better error message
     let availableTools: string[] | undefined;

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -24,6 +24,9 @@ describe('CLI Integration Tests', () => {
     testFilePath = join(tempDir, 'test.txt');
     await writeFile(testFilePath, 'Hello from test file!');
 
+    // Create a large file for pipe/truncation regression coverage
+    await writeFile(join(tempDir, 'large.txt'), 'x'.repeat(100000));
+
     // Create subdirectory with more files
     const subDir = join(tempDir, 'subdir');
     await mkdir(subDir);
@@ -262,6 +265,28 @@ describe('CLI Integration Tests', () => {
       expect(result.stdout).not.toContain('"content"');
       expect(result.stdout).not.toContain('"type"');
       expect(result.stdout).not.toContain('"text"');
+    });
+
+    test('does not truncate large output when piped (issue #23)', async () => {
+      const cliPath = join(import.meta.dir, '..', '..', 'src', 'index.ts');
+      const largeFilePath = join(tempDir, 'large.txt');
+      const args = JSON.stringify({ path: largeFilePath });
+
+      const proc = Bun.spawn(
+        ['bun', 'run', cliPath, '-c', configPath, 'call', 'filesystem', 'read_file', args],
+        {
+          cwd: process.cwd(),
+          env: { ...process.env, MCP_NO_DAEMON: '1' },
+          stdout: 'pipe',
+          stderr: 'pipe',
+        }
+      );
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      const exitCode = await proc.exited;
+
+      expect(exitCode).toBe(0);
+      expect(stdout.length).toBe(100001);
     });
   });
 


### PR DESCRIPTION
## Summary
- switch `call` command stdout emission from `console.log()` to `process.stdout.write()`
- add an integration regression test covering large tool output through a piped stdout stream

## Why
Issue #23 reports that large tool output is truncated at 65536 bytes when `mcp-cli call ...` is piped to another process. The root cause is the use of `console.log()` for the final tool result emission under Bun in non-TTY/pipe scenarios.

Using `process.stdout.write()` preserves the full output while keeping the existing trailing newline behavior.

## Validation
- `bun test tests/integration/cli.test.ts -t 'does not truncate large output when piped'`
- `bun run typecheck`
- `git diff --check`
