### PR TITLE
test: cover empty mcpServers warning

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for config module
  */
 
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -171,6 +171,27 @@ describe('config', () => {
       );
 
       await expect(loadConfig(configPath)).rejects.toThrow('Invalid server configuration');
+    });
+
+    test('warns but loads when mcpServers is empty', async () => {
+      const configPath = join(tempDir, 'empty_servers.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {},
+        })
+      );
+
+      const warn = spyOn(console, 'error').mockImplementation(() => undefined);
+      try {
+        const config = await loadConfig(configPath);
+        expect(config.mcpServers).toEqual({});
+        expect(warn).toHaveBeenCalledWith(
+          '[mcp-cli] Warning: No servers configured in mcpServers. Add server configurations to use MCP tools.',
+        );
+      } finally {
+        warn.mockRestore();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- add config-loader coverage for the `mcpServers: {}` case
- verify `loadConfig()` still succeeds when no servers are configured
- verify the existing warning message is emitted so users get feedback instead of a silent no-op

## Why
`loadConfig()` intentionally treats an empty `mcpServers` object as a warning, not a fatal error, but that behavior was untested. This PR locks down the current UX contract so future refactors do not accidentally turn it into either a hard failure or a silent success.

## Validation
- `bun test tests/config.test.ts -t 'warns but loads when mcpServers is empty'`
- `bun run typecheck`
- `git diff --check`
