### PR TITLE
test: cover empty listServerNames

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -207,6 +207,19 @@ describe('config', () => {
   });
 
   describe('listServerNames', () => {
+    test('returns empty array when no servers are configured', async () => {
+      const configPath = join(tempDir, 'empty-config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {},
+        })
+      );
+
+      const config = await loadConfig(configPath);
+      expect(listServerNames(config)).toEqual([]);
+    });
+
     test('returns all server names', async () => {
       const configPath = join(tempDir, 'config.json');
       await writeFile(


### PR DESCRIPTION
## Summary
- add config helper coverage for `listServerNames()` when `mcpServers` is empty
- verify the helper returns `[]` for the warning-only empty-config case

## Why
`loadConfig()` intentionally allows `mcpServers: {}` with a warning, and `listServerNames()` should stay safe on that same config shape. This PR locks down the empty-array behavior so future refactors do not accidentally throw or return a misleading value.

## Validation
- `bun test tests/config.test.ts -t 'returns empty array when no servers are configured'`
- `bun run typecheck`
- `git diff --check`
