### PR TITLE
test: cover empty getServerConfig lookup

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -204,6 +204,19 @@ describe('config', () => {
       const config = await loadConfig(configPath);
       expect(() => getServerConfig(config, 'unknown')).toThrow('not found');
     });
+
+    test('throws not found for empty configured servers', async () => {
+      const configPath = join(tempDir, 'empty_servers_for_lookup.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {},
+        })
+      );
+
+      const config = await loadConfig(configPath);
+      expect(() => getServerConfig(config, 'anything')).toThrow('not found');
+    });
   });
 
   describe('listServerNames', () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -207,6 +207,19 @@ describe('config', () => {
   });
 
   describe('listServerNames', () => {
+    test('returns empty array when no servers are configured', async () => {
+      const configPath = join(tempDir, 'empty-config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {},
+        })
+      );
+
+      const config = await loadConfig(configPath);
+      expect(listServerNames(config)).toEqual([]);
+    });
+
     test('returns all server names', async () => {
       const configPath = join(tempDir, 'config.json');
       await writeFile(


### PR DESCRIPTION
## Summary
- add config helper coverage for `getServerConfig()` when `mcpServers` is empty
- verify lookup still raises the expected `not found` error on the warning-only empty-config path

## Why
`loadConfig()` intentionally allows `mcpServers: {}` with a warning, and helper lookups should remain predictable on that config shape. This PR locks down the current behavior so future refactors do not accidentally throw a different error or mis-handle empty configs.

## Validation
- `bun test tests/config.test.ts -t 'throws not found for empty configured servers'`
- `git diff --check`
