### PR TITLE
test: cover listServerNames order

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -227,6 +227,24 @@ describe('config', () => {
       expect(names).toContain('gamma');
       expect(names.length).toBe(3);
     });
+
+
+    test('preserves declaration order of server names', async () => {
+      const configPath = join(tempDir, 'config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            gamma: { url: 'https://example.com' },
+            alpha: { command: 'a' },
+            beta: { command: 'b' },
+          },
+        })
+      );
+
+      const config = await loadConfig(configPath);
+      expect(listServerNames(config)).toEqual(['gamma', 'alpha', 'beta']);
+    });
   });
 
   describe('type guards', () => {


### PR DESCRIPTION
## Summary
- add a focused config test for `listServerNames()` ordering
- verify server names are returned in declaration order instead of being reordered implicitly
- lock in stable output for CLI surfaces that render configured server lists

## Validation
- `bun test tests/config.test.ts -t 'preserves declaration order of server names'`
- `bun run typecheck`
- `git diff --check`
