### PR TITLE
test: cover http type guard with headers

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -235,6 +235,16 @@ describe('config', () => {
       expect(isHttpServer({ command: 'echo' })).toBe(false);
     });
 
+
+    test('isHttpServer accepts HTTP config with headers', () => {
+      expect(
+        isHttpServer({
+          url: 'https://example.com',
+          headers: { Authorization: 'Bearer token' },
+        })
+      ).toBe(true);
+    });
+
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);


### PR DESCRIPTION
## Summary
- add a focused config type-guard test for HTTP servers with headers
- verify `isHttpServer()` still recognizes richer HTTP configs, not just the minimal `url`-only shape
- lock in behavior for command surfaces that accept authenticated HTTP MCP servers

## Validation
- `bun test tests/config.test.ts -t 'isHttpServer accepts HTTP config with headers'`
- `bun run typecheck`
- `git diff --check`
