### PR TITLE
test: cover stdio type guard with args env

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -239,5 +239,16 @@ describe('config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
     });
+
+
+    test('isStdioServer accepts stdio config with args and env', () => {
+      expect(
+        isStdioServer({
+          command: 'echo',
+          args: ['hello'],
+          env: { GREETING: 'world' },
+        })
+      ).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add a focused config type-guard test for richer stdio server configs
- verify `isStdioServer()` still recognizes stdio servers when `args` and `env` are present
- lock in behavior for command surfaces that pass configured process arguments and environment variables

## Validation
- `bun test tests/config.test.ts -t 'isStdioServer accepts stdio config with args and env'`
- `bun run typecheck`
- `git diff --check`
