### PR TITLE
fix: reject mixed http/stdio server shapes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -156,7 +156,7 @@ export function isHttpServer(config: ServerConfig): config is HttpServerConfig {
 export function isStdioServer(
   config: ServerConfig,
 ): config is StdioServerConfig {
-  return 'command' in config;
+  return 'command' in config && !('url' in config);
 }
 
 // ============================================================================

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -239,5 +239,15 @@ describe('config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
     });
+
+
+    test('rejects mixed url+command shape as stdio config', () => {
+      expect(
+        isStdioServer({
+          url: 'https://example.com',
+          command: 'echo',
+        })
+      ).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- fix `isStdioServer()` so mixed HTTP+stdio shapes are not misclassified as stdio servers
- add a regression test covering objects that contain both `url` and `command`
- preserve the guard boundary between HTTP and stdio server configs

## Validation
- `bun test tests/config.test.ts -t 'mixed url'`
- `bun run typecheck`
- `git diff --check`
