### PR TITLE
fix: reject mixed http/stdio server shapes in http guard

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -147,7 +147,7 @@ export function isToolAllowed(toolName: string, config: ServerConfig): boolean {
  * Check if a server config is HTTP-based
  */
 export function isHttpServer(config: ServerConfig): config is HttpServerConfig {
-  return 'url' in config;
+  return 'url' in config && !('command' in config);
 }
 
 /**

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -235,6 +235,15 @@ describe('config', () => {
       expect(isHttpServer({ command: 'echo' })).toBe(false);
     });
 
+    test('rejects mixed url+command shape as http config', () => {
+      expect(
+        isHttpServer({
+          url: 'https://example.com',
+          command: 'echo',
+        })
+      ).toBe(false);
+    });
+
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);


### PR DESCRIPTION
## Summary
- fix `isHttpServer()` so mixed HTTP+stdio shapes are not misclassified as HTTP servers
- add a regression test covering objects that contain both `url` and `command`
- keep the HTTP and stdio guard boundaries symmetric and explicit

## Validation
- `bun test tests/config.test.ts -t 'mixed url'`
- `bun run typecheck`
- `git diff --check`
