### PR TITLE
test: cover filterTools precedence

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -12,6 +12,7 @@ import {
   listServerNames,
   isHttpServer,
   isStdioServer,
+  filterTools,
 } from '../src/config';
 
 describe('config', () => {
@@ -238,6 +239,25 @@ describe('config', () => {
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
+    });
+  });
+
+
+  describe('filterTools', () => {
+    test('disabledTools takes precedence over allowedTools', () => {
+      const tools = [
+        { name: 'read_file' },
+        { name: 'write_file' },
+        { name: 'grep_file' },
+      ];
+
+      const filtered = filterTools(tools, {
+        command: 'echo',
+        allowedTools: ['*_file'],
+        disabledTools: ['write_*'],
+      });
+
+      expect(filtered.map((tool) => tool.name)).toEqual(['read_file', 'grep_file']);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a focused config test for `filterTools()` precedence rules
- verify `disabledTools` still overrides `allowedTools` when both patterns match
- lock in the documented filtering behavior for MCP server tool exposure

## Validation
- `/home/node/bin/bun test tests/config.test.ts -t 'disabledTools takes precedence over allowedTools'`
- `/home/node/bin/bun run typecheck`
- `git diff --check`
