### PR TITLE
test: cover filterTools behavior

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -12,6 +12,7 @@ import {
   listServerNames,
   isHttpServer,
   isStdioServer,
+  filterTools,
 } from '../src/config';
 
 describe('config', () => {
@@ -238,6 +239,43 @@ describe('config', () => {
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
+    });
+  });
+
+
+  describe('filterTools', () => {
+    test('disabledTools takes precedence over allowedTools', () => {
+      const tools = [
+        { name: 'read_file' },
+        { name: 'write_file' },
+        { name: 'grep_file' },
+      ];
+
+      const filtered = filterTools(tools, {
+        command: 'echo',
+        allowedTools: ['*_file'],
+        disabledTools: ['write_*'],
+      });
+
+      expect(filtered.map((tool) => tool.name)).toEqual(['read_file', 'grep_file']);
+    });
+
+    test('returns all tools when no filters are configured', () => {
+      const tools = [
+        { name: 'read_file' },
+        { name: 'write_file' },
+        { name: 'grep_file' },
+      ];
+
+      const filtered = filterTools(tools, {
+        command: 'echo',
+      });
+
+      expect(filtered.map((tool) => tool.name)).toEqual([
+        'read_file',
+        'write_file',
+        'grep_file',
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add focused config tests for `filterTools()` behavior
- verify `disabledTools` overrides `allowedTools` when both match
- verify the default path preserves all tools when no filters are configured

## Validation
- `bun test tests/config.test.ts -t 'filterTools'`
- `bun run typecheck`
- `git diff --check`
