### PR TITLE
test: cover mixed command/url config rejection

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -204,6 +204,24 @@ describe('config', () => {
       const config = await loadConfig(configPath);
       expect(() => getServerConfig(config, 'unknown')).toThrow('not found');
     });
+
+
+    test('rejects server configs that specify both command and url', async () => {
+      const configPath = join(tempDir, 'config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            mixed: {
+              command: 'echo',
+              url: 'https://example.com',
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('has both "command" and "url"');
+    });
   });
 
   describe('listServerNames', () => {


### PR DESCRIPTION
## Summary
- add a focused config-loader test for mixed server shapes
- verify `loadConfig()` rejects entries that specify both `command` and `url`
- lock in the config-level boundary between stdio and HTTP server definitions

## Validation
- `bun test tests/config.test.ts -t 'rejects server configs that specify both command and url'`
- `bun run typecheck`
- `git diff --check`
