### PR TITLE
test: cover missing command/url config error

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -206,6 +206,23 @@ describe('config', () => {
     });
   });
 
+    test('rejects server configs missing both command and url', async () => {
+      const configPath = join(tempDir, 'config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            invalid: {
+              env: { TOKEN: 'abc' },
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('missing required field');
+      await expect(loadConfig(configPath)).rejects.toThrow('either "command" (for stdio) or "url" (for HTTP)');
+    });
+
   describe('listServerNames', () => {
     test('returns all server names', async () => {
       const configPath = join(tempDir, 'config.json');


### PR DESCRIPTION
## Summary
- add a focused config-loader test for invalid server shapes with neither `command` nor `url`
- verify `loadConfig()` reports both the missing-field condition and the stdio-vs-HTTP guidance text
- lock in the config-level error message contract for malformed server entries

## Validation
- `bun test tests/config.test.ts -t 'rejects server configs missing both command and url'`
- `bun run typecheck`
- `git diff --check`
