### PR TITLE
test: cover non-object server config error

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -172,6 +172,22 @@ describe('config', () => {
 
       await expect(loadConfig(configPath)).rejects.toThrow('Invalid server configuration');
     });
+
+
+    test('throws object-specific error on string server config', async () => {
+      const configPath = join(tempDir, 'string_server.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            broken: 'echo hello',
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Invalid server configuration for "broken"');
+      await expect(loadConfig(configPath)).rejects.toThrow('Server config must be an object');
+    });
   });
 
   describe('getServerConfig', () => {


### PR DESCRIPTION
## Summary
- add a focused config-loader test for non-object server configs
- verify `loadConfig()` reports both the server name and the object-specific validation message
- lock in the malformed-config error contract for string-valued server entries

## Validation
- `bun test tests/config.test.ts -t 'throws object-specific error on string server config'`
- `bun run typecheck`
- `git diff --check`
