### PR TITLE
test: cover numeric server config error

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -174,6 +174,21 @@ describe('config', () => {
     });
   });
 
+    test('throws object-specific error on numeric server config', async () => {
+      const configPath = join(tempDir, 'number_server.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            numeric: 42,
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Invalid server configuration for "numeric"');
+      await expect(loadConfig(configPath)).rejects.toThrow('Server config must be an object');
+    });
+
   describe('getServerConfig', () => {
     test('returns server config by name', async () => {
       const configPath = join(tempDir, 'config.json');


### PR DESCRIPTION
## Summary
- add a focused config-loader test for numeric server configs
- verify non-object numeric entries keep the same server-specific validation contract as other primitive malformed values
- lock in the malformed-config error shape across multiple primitive value types

## Validation
- `bun test tests/config.test.ts -t 'throws object-specific error on numeric server config'`
- `bun run typecheck`
- `git diff --check`
