### PR TITLE
test: cover boolean server config error

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -174,6 +174,21 @@ describe('config', () => {
     });
   });
 
+    test('throws object-specific error on boolean server config', async () => {
+      const configPath = join(tempDir, 'boolean_server.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            booleanish: true,
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Invalid server configuration for "booleanish"');
+      await expect(loadConfig(configPath)).rejects.toThrow('Server config must be an object');
+    });
+
   describe('getServerConfig', () => {
     test('returns server config by name', async () => {
       const configPath = join(tempDir, 'config.json');


### PR DESCRIPTION
## Summary
- add a focused config-loader test for boolean server configs
- verify primitive malformed entries keep the same server-specific validation contract as other non-object shapes
- lock in the malformed-config error shape across another primitive type

## Validation
- `bun test tests/config.test.ts -t 'throws object-specific error on boolean server config'`
- `bun run typecheck`
- `git diff --check`
