### PR TITLE
test: cover false server config error

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -174,6 +174,21 @@ describe('config', () => {
     });
   });
 
+    test('throws object-specific error on false server config', async () => {
+      const configPath = join(tempDir, 'false_server.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            falsy: false,
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Invalid server configuration for "falsy"');
+      await expect(loadConfig(configPath)).rejects.toThrow('Server config must be an object');
+    });
+
   describe('getServerConfig', () => {
     test('returns server config by name', async () => {
       const configPath = join(tempDir, 'config.json');


### PR DESCRIPTION
## Summary
- add a focused config-loader test for `false` server configs
- verify boolean malformed entries keep the same server-specific validation contract on the falsy branch too
- lock in the malformed-config error shape across both boolean values

## Validation
- `bun test tests/config.test.ts -t 'throws object-specific error on false server config'`
- `bun run typecheck`
- `git diff --check`
