### PR TITLE
test: cover array server config shape error

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -174,6 +174,21 @@ describe('config', () => {
     });
   });
 
+    test('treats array server config as missing command/url shape', async () => {
+      const configPath = join(tempDir, 'array_server.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            listy: [],
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Server "listy" missing required field');
+      await expect(loadConfig(configPath)).rejects.toThrow('either "command" (for stdio) or "url" (for HTTP)');
+    });
+
   describe('getServerConfig', () => {
     test('returns server config by name', async () => {
       const configPath = join(tempDir, 'config.json');


### PR DESCRIPTION
## Summary
- add a focused config-loader test for array-valued server configs
- verify array entries are currently rejected via the missing command/url validation path
- lock in the actual malformed-config contract for collection-like invalid entries

## Validation
- `bun test tests/config.test.ts -t 'treats array server config as missing command/url shape'`
- `bun run typecheck`
- `git diff --check`
