### PR TITLE
test: cover args-only server config error

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -174,6 +174,23 @@ describe('config', () => {
     });
   });
 
+    test('rejects args-only server config as missing command/url shape', async () => {
+      const configPath = join(tempDir, 'args_only_server.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            argsonly: {
+              args: ['--help'],
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Server "argsonly" missing required field');
+      await expect(loadConfig(configPath)).rejects.toThrow('either "command" (for stdio) or "url" (for HTTP)');
+    });
+
   describe('getServerConfig', () => {
     test('returns server config by name', async () => {
       const configPath = join(tempDir, 'config.json');


### PR DESCRIPTION
## Summary
- add a focused config-loader test for args-only server configs
- verify object-like malformed entries without `command` or `url` are rejected through the missing-field path
- lock in a realistic misconfiguration contract for stdio server definitions

## Validation
- `bun test tests/config.test.ts -t 'rejects args-only server config as missing command/url shape'`
- `bun run typecheck`
- `git diff --check`
