### PR TITLE
test: cover headers-only server config error

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -174,6 +174,23 @@ describe('config', () => {
     });
   });
 
+    test('rejects headers-only server config as missing command/url shape', async () => {
+      const configPath = join(tempDir, 'headers_only_server.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            headersonly: {
+              headers: { Authorization: 'Bearer token' },
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Server "headersonly" missing required field');
+      await expect(loadConfig(configPath)).rejects.toThrow('either "command" (for stdio) or "url" (for HTTP)');
+    });
+
   describe('getServerConfig', () => {
     test('returns server config by name', async () => {
       const configPath = join(tempDir, 'config.json');


### PR DESCRIPTION
## Summary
- add a focused config-loader test for headers-only server configs
- verify HTTP-like malformed entries without `url` are rejected through the missing-field path
- lock in a realistic misconfiguration contract for HTTP server definitions

## Validation
- `bun test tests/config.test.ts -t 'rejects headers-only server config as missing command/url shape'`
- `bun run typecheck`
- `git diff --check`
