### PR TITLE
test: cover env-only server config error

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -174,6 +174,23 @@ describe('config', () => {
     });
   });
 
+    test('rejects env-only server config as missing command/url shape', async () => {
+      const configPath = join(tempDir, 'env_only_server.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            envonly: {
+              env: { TOKEN: 'abc' },
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Server "envonly" missing required field');
+      await expect(loadConfig(configPath)).rejects.toThrow('either "command" (for stdio) or "url" (for HTTP)');
+    });
+
   describe('getServerConfig', () => {
     test('returns server config by name', async () => {
       const configPath = join(tempDir, 'config.json');


### PR DESCRIPTION
## Summary
- add a focused config-loader test for env-only server configs
- verify stdio-like malformed entries without `command` are rejected through the missing-field path
- lock in another realistic misconfiguration contract for local server definitions

## Validation
- `bun test tests/config.test.ts -t 'rejects env-only server config as missing command/url shape'`
- `bun run typecheck`
- `git diff --check`
