### PR TITLE
test: cover timeout-only server config error

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -174,6 +174,23 @@ describe('config', () => {
     });
   });
 
+    test('rejects timeout-only server config as missing command/url shape', async () => {
+      const configPath = join(tempDir, 'timeout_only_server.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            timeoutonly: {
+              timeout: 5000,
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Server "timeoutonly" missing required field');
+      await expect(loadConfig(configPath)).rejects.toThrow('either "command" (for stdio) or "url" (for HTTP)');
+    });
+
   describe('getServerConfig', () => {
     test('returns server config by name', async () => {
       const configPath = join(tempDir, 'config.json');


### PR DESCRIPTION
## Summary
- add a focused config-loader test for timeout-only server configs
- verify HTTP-like malformed entries without `url` are rejected through the missing-field path even when they include another plausible option
- lock in another realistic misconfiguration contract for remote server definitions

## Validation
- `bun test tests/config.test.ts -t 'rejects timeout-only server config as missing command/url shape'`
- `bun run typecheck`
- `git diff --check`
