### PR TITLE
test: cover retries-only server config error

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -174,6 +174,23 @@ describe('config', () => {
     });
   });
 
+    test('rejects retries-only server config as missing command/url shape', async () => {
+      const configPath = join(tempDir, 'retries_only_server.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            retriesonly: {
+              retries: 3,
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Server "retriesonly" missing required field');
+      await expect(loadConfig(configPath)).rejects.toThrow('either "command" (for stdio) or "url" (for HTTP)');
+    });
+
   describe('getServerConfig', () => {
     test('returns server config by name', async () => {
       const configPath = join(tempDir, 'config.json');


### PR DESCRIPTION
## Summary
- add a focused config-loader test for retries-only server configs
- verify HTTP-like malformed entries without `url` are rejected through the missing-field path even when they include retry settings
- lock in another realistic misconfiguration contract for remote server definitions

## Validation
- `bun test tests/config.test.ts -t 'rejects retries-only server config as missing command/url shape'`
- `bun run typecheck`
- `git diff --check`
