### PR TITLE
fix: stabilize config hash for nested objects

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -298,8 +298,29 @@ export function getPidPath(serverName: string): string {
  * Generate a hash of server config for stale detection
  * Returns consistent hash for identical configs
  */
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).sort(
+      ([a], [b]) => a.localeCompare(b),
+    );
+
+    return `{${entries
+      .map(
+        ([key, entryValue]) =>
+          `${JSON.stringify(key)}:${stableStringify(entryValue)}`,
+      )
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
 export function getConfigHash(config: ServerConfig): string {
-  const str = JSON.stringify(config, Object.keys(config).sort());
+  const str = stableStringify(config);
   // Simple hash using Bun's native hashing
   const hasher = new Bun.CryptoHasher('sha256');
   hasher.update(str);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -12,6 +12,7 @@ import {
   listServerNames,
   isHttpServer,
   isStdioServer,
+  getConfigHash,
 } from '../src/config';
 
 describe('config', () => {
@@ -255,6 +256,28 @@ describe('config', () => {
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
+    });
+  });
+
+  describe('getConfigHash', () => {
+    test('returns the same hash for nested objects with different key order', () => {
+      const first = getConfigHash({
+        url: 'https://example.com',
+        headers: {
+          Authorization: 'Bearer token',
+          'X-Trace-Id': 'abc',
+        },
+      });
+
+      const second = getConfigHash({
+        headers: {
+          'X-Trace-Id': 'abc',
+          Authorization: 'Bearer token',
+        },
+        url: 'https://example.com',
+      });
+
+      expect(first).toBe(second);
     });
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -174,6 +174,23 @@ describe('config', () => {
     });
   });
 
+    test('rejects cache-only server config as missing command/url shape', async () => {
+      const configPath = join(tempDir, 'cache_only_server.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            cacheonly: {
+              cache: true,
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Server "cacheonly" missing required field');
+      await expect(loadConfig(configPath)).rejects.toThrow('either "command" (for stdio) or "url" (for HTTP)');
+    });
+
   describe('getServerConfig', () => {
     test('returns server config by name', async () => {
       const configPath = join(tempDir, 'config.json');


### PR DESCRIPTION
$## Summary\n- make `getConfigHash()` recursively sort nested object keys before hashing\n- keep array ordering intact while normalizing object key order\n- add a regression test covering equivalent nested `headers` objects with different key order\n\n## Why\nDaemon stale detection compares config hashes. Before this change, semantically identical configs could hash differently when nested object keys (for example `headers` or `env`) were serialized in a different insertion order, causing unnecessary daemon restarts or stale mismatches.\n\n## Testing\n- `bun test tests/config.test.ts`