### PR TITLE
fix: scope env substitution to target server

### DIFF
--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -108,17 +108,37 @@ async function parseArgs(
  * Execute the call command
  */
 export async function callCommand(options: CallOptions): Promise<void> {
-  let config: McpServersConfig;
+  let serverName: string;
+  let toolName: string;
 
   try {
-    config = await loadConfig(options.configPath);
+    const parsed = parseTarget(options.target);
+    serverName = parsed.server;
+    toolName = parsed.tool;
   } catch (error) {
     console.error((error as Error).message);
     process.exit(ErrorCode.CLIENT_ERROR);
   }
 
-  let serverName: string;
-  let toolName: string;
+  let config: McpServersConfig;
+
+  try {
+    config = await loadConfig(options.configPath, {
+      envServerNames: [serverName],
+    });
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exit(ErrorCode.CLIENT_ERROR);
+  }
+-
+-  try {
+-    const parsed = parseTarget(options.target);
+-    serverName = parsed.server;
+-    toolName = parsed.tool;
+-  } catch (error) {
+-    console.error((error as Error).message);
+-    process.exit(ErrorCode.CLIENT_ERROR);
+-  }
 
   try {
     const parsed = parseTarget(options.target);

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -38,16 +38,18 @@ function parseTarget(target: string): { server: string; tool?: string } {
  * Execute the info command
  */
 export async function infoCommand(options: InfoOptions): Promise<void> {
+  const { server: serverName, tool: toolName } = parseTarget(options.target);
+
   let config: McpServersConfig;
 
   try {
-    config = await loadConfig(options.configPath);
+    config = await loadConfig(options.configPath, {
+      envServerNames: [serverName],
+    });
   } catch (error) {
     console.error((error as Error).message);
     process.exit(ErrorCode.CLIENT_ERROR);
   }
-
-  const { server: serverName, tool: toolName } = parseTarget(options.target);
 
   let serverConfig: ServerConfig;
   try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,10 @@ export interface McpServersConfig {
   mcpServers: Record<string, ServerConfig>;
 }
 
+export interface LoadConfigOptions {
+  envServerNames?: string[];
+}
+
 // ============================================================================
 // Tool Filtering
 // ============================================================================
@@ -398,6 +402,7 @@ function getDefaultConfigPaths(): string[] {
  */
 export async function loadConfig(
   explicitPath?: string,
+  options?: LoadConfigOptions,
 ): Promise<McpServersConfig> {
   let configPath: string | undefined;
 
@@ -497,7 +502,23 @@ export async function loadConfig(
   }
 
   // Substitute environment variables
-  config = substituteEnvVarsInObject(config);
+  if (options?.envServerNames && options.envServerNames.length > 0) {
+    const serverNames = new Set(options.envServerNames);
+    const substitutedServers: Record<string, ServerConfig> = {};
+
+    for (const [serverName, serverConfig] of Object.entries(config.mcpServers)) {
+      substitutedServers[serverName] = serverNames.has(serverName)
+        ? substituteEnvVarsInObject(serverConfig)
+        : serverConfig;
+    }
+
+    config = {
+      ...config,
+      mcpServers: substitutedServers,
+    };
+  } else {
+    config = substituteEnvVarsInObject(config);
+  }
 
   return config;
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -128,6 +128,41 @@ describe('config', () => {
       await expect(loadConfig(configPath)).rejects.toThrow('MISSING_ENV_VAR');
     });
 
+    test('only substitutes env vars for requested servers when scoped', async () => {
+      delete process.env.MCP_STRICT_ENV;
+      process.env.TARGET_SERVER_TOKEN = 'scoped-secret';
+
+      const configPath = join(tempDir, 'scoped_env.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            target: {
+              url: 'https://example.com',
+              headers: { Authorization: 'Bearer ${TARGET_SERVER_TOKEN}' },
+            },
+            unrelated: {
+              command: 'echo',
+              env: { TOKEN: '${UNRELATED_MISSING_VAR}' },
+            },
+          },
+        })
+      );
+
+      const config = await loadConfig(configPath, {
+        envServerNames: ['target'],
+      });
+
+      expect((config.mcpServers.target as any).headers.Authorization).toBe(
+        'Bearer scoped-secret'
+      );
+      expect((config.mcpServers.unrelated as any).env.TOKEN).toBe(
+        '${UNRELATED_MISSING_VAR}'
+      );
+
+      delete process.env.TARGET_SERVER_TOKEN;
+    });
+
     test('throws error on empty server config', async () => {
       const configPath = join(tempDir, 'empty_server.json');
       await writeFile(


### PR DESCRIPTION
$## Summary\n- add scoped env substitution support to `loadConfig()`\n- use scoped substitution in `info` and `call` so targeted commands only resolve env vars for the requested server\n- add a regression test covering an unrelated server with missing env vars\n\n## Why\nWhen a user runs a targeted command like `mcp-cli info chrome-devtools`, the CLI should not warn about missing env vars referenced by other servers in the same config. This change keeps those warnings scoped to the server actually being accessed while preserving full-config substitution for commands that load every server.\n\n## Testing\n- `bun test tests/config.test.ts`