### PR TITLE
fix: only show server stderr when MCP_DEBUG is set

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -244,14 +244,16 @@ export async function connectToServer(
       transport = createStdioTransport(config);
 
       // Capture stderr for debugging - attach BEFORE connect
-      // Always stream stderr immediately so auth prompts are visible
+      // Only stream stderr when MCP_DEBUG is set to avoid noise
       const stderrStream = transport.stderr;
       if (stderrStream) {
         stderrStream.on('data', (chunk: Buffer) => {
           const text = chunk.toString();
           stderrChunks.push(text);
-          // Always stream stderr immediately so users can see auth prompts
-          process.stderr.write(`[${serverName}] ${text}`);
+          // Only stream stderr when debug mode is enabled
+          if (process.env.MCP_DEBUG) {
+            process.stderr.write(`[${serverName}] ${text}`);
+          }
         });
       }
     }
@@ -268,8 +270,8 @@ export async function connectToServer(
       throw error;
     }
 
-    // For successful connections, forward stderr to console
-    if (!isHttpServer(config)) {
+    // For successful connections, forward stderr to console only in debug mode
+    if (!isHttpServer(config) && process.env.MCP_DEBUG) {
       const stderrStream = (transport as StdioClientTransport).stderr;
       if (stderrStream) {
         stderrStream.on('data', (chunk: Buffer) => {


### PR DESCRIPTION
$## Summary\n- gate server stderr output behind `MCP_DEBUG` environment variable\n- during connection: only stream stderr when debug mode is enabled\n- after successful connection: only forward stderr when debug mode is enabled\n\n## Why\nWhen agents execute `mcp-cli`, server stderr output adds noise and consumes tokens unnecessarily. This change aligns stderr behavior with the existing `debug()` utility pattern—only showing diagnostic output when `MCP_DEBUG` is explicitly set.\n\n## Testing\n- `bun test tests/output.test.ts tests/config.test.ts` (26/26 passing)\n- stderr is no longer printed during normal operation\n- stderr appears when `MCP_DEBUG=1` is set\n\nFixes #17