### PR TITLE
test: cover cwd-only server config error

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -172,6 +172,22 @@ describe('config', () => {
 
       await expect(loadConfig(configPath)).rejects.toThrow('Invalid server configuration');
     });
+
+    test('throws error on server with cwd but no command', async () => {
+      const configPath = join(tempDir, 'cwd_only.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            badserver: {
+              cwd: '/tmp/mcp-server',
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('missing required field');
+    });
   });
 
   describe('getServerConfig', () => {


### PR DESCRIPTION
$## Summary\n- add coverage for a server entry that only sets `cwd` without a `command`\n- assert it is rejected via the existing missing required field validation path\n\n## Testing\n- bun test tests/config.test.ts -t "throws error on server with cwd but no command"\n- bun run typecheck\n- git diff --check