### PR TITLE
test: cover disabledTools-only server config error

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -172,6 +172,22 @@ describe('config', () => {
 
       await expect(loadConfig(configPath)).rejects.toThrow('Invalid server configuration');
     });
+
+    test('throws error on server with disabledTools but no command or url', async () => {
+      const configPath = join(tempDir, 'disabled_tools_only.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            badserver: {
+              disabledTools: ['write_*'],
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('missing required field');
+    });
   });
 
   describe('getServerConfig', () => {


### PR DESCRIPTION
$## Summary\n- add coverage for a server entry that only sets `disabledTools` without a `command` or `url`\n- assert it is rejected via the existing missing required field validation path\n\n## Testing\n- bun test tests/config.test.ts -t "throws error on server with disabledTools but no command or url"\n- bun run typecheck\n- git diff --check