### PR TITLE
fix: reject transport-specific config fields

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -494,6 +494,30 @@ export async function loadConfig(
         }),
       );
     }
+
+    if (hasUrl && ('cwd' in serverConfig || 'args' in serverConfig || 'env' in serverConfig)) {
+      throw new Error(
+        formatCliError({
+          code: ErrorCode.CLIENT_ERROR,
+          type: 'CONFIG_INVALID_SERVER',
+          message: `HTTP server "${serverName}" has stdio-only fields`,
+          details: 'HTTP servers support url, headers, timeout, allowedTools, and disabledTools only',
+          suggestion: 'Remove stdio-only fields like command args, env, or cwd from HTTP server configs',
+        }),
+      );
+    }
+
+    if (hasCommand && ('headers' in serverConfig || 'timeout' in serverConfig)) {
+      throw new Error(
+        formatCliError({
+          code: ErrorCode.CLIENT_ERROR,
+          type: 'CONFIG_INVALID_SERVER',
+          message: `Stdio server "${serverName}" has HTTP-only fields`,
+          details: 'Stdio servers support command, args, env, cwd, allowedTools, and disabledTools only',
+          suggestion: 'Remove HTTP-only fields like url, headers, or timeout from stdio server configs',
+        }),
+      );
+    }
   }
 
   // Substitute environment variables

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -159,6 +159,40 @@ describe('config', () => {
       await expect(loadConfig(configPath)).rejects.toThrow('both "command" and "url"');
     });
 
+    test('throws error on HTTP server config with cwd and url', async () => {
+      const configPath = join(tempDir, 'cwd_and_url.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            mixed: {
+              cwd: '/tmp/mcp-server',
+              url: 'https://example.com/sse',
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('stdio-only fields');
+    });
+
+    test('throws error on stdio server config with headers and command', async () => {
+      const configPath = join(tempDir, 'command_and_headers.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            mixed: {
+              command: 'echo',
+              headers: { Authorization: 'Bearer token' },
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('HTTP-only fields');
+    });
+
     test('throws error on null server config', async () => {
       const configPath = join(tempDir, 'null_server.json');
       await writeFile(


### PR DESCRIPTION
$## Summary\n- reject stdio-only fields on HTTP server configs\n- reject HTTP-only fields on stdio server configs\n- add focused regression tests for both mixed-shape cases\n\n## Testing\n- bun test tests/config.test.ts -t "throws error on HTTP server config with cwd and url|throws error on stdio server config with headers and command"\n- bun run typecheck\n- git diff --check