### PR TITLE
test: cover daemon env flag parsing

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -7,15 +7,17 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  loadConfig,
   getServerConfig,
-  listServerNames,
+  isDaemonEnabled,
   isHttpServer,
   isStdioServer,
+  listServerNames,
+  loadConfig,
 } from '../src/config';
 
 describe('config', () => {
   let tempDir: string;
+  const originalNoDaemon = process.env.MCP_NO_DAEMON;
 
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'mcp-cli-test-'));
@@ -23,6 +25,7 @@ describe('config', () => {
 
   afterEach(async () => {
     await rm(tempDir, { recursive: true, force: true });
+    process.env.MCP_NO_DAEMON = originalNoDaemon;
   });
 
   describe('loadConfig', () => {
@@ -238,6 +241,22 @@ describe('config', () => {
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
+    });
+  });
+
+  describe('daemon env flag parsing', () => {
+    test('disables daemon mode only when MCP_NO_DAEMON is set to 1', () => {
+      delete process.env.MCP_NO_DAEMON;
+      expect(isDaemonEnabled()).toBe(true);
+
+      process.env.MCP_NO_DAEMON = '0';
+      expect(isDaemonEnabled()).toBe(true);
+
+      process.env.MCP_NO_DAEMON = 'true';
+      expect(isDaemonEnabled()).toBe(true);
+
+      process.env.MCP_NO_DAEMON = '1';
+      expect(isDaemonEnabled()).toBe(false);
     });
   });
 });


### PR DESCRIPTION
$## Summary\n- add regression coverage for `MCP_NO_DAEMON` parsing\n- lock the current behavior that daemon mode is disabled only when the env var is exactly `1`\n- cover nearby non-disabling values like `0` and `true` to avoid accidental broadening of the flag semantics\n\n## Testing\n- bun test tests/config.test.ts -t "disables daemon mode only when MCP_NO_DAEMON is set to 1"\n- bun run typecheck\n- git diff --check