### PR TITLE
test: cover server name order contract

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -227,6 +227,23 @@ describe('config', () => {
       expect(names).toContain('gamma');
       expect(names.length).toBe(3);
     });
+
+    test('preserves declaration order', async () => {
+      const configPath = join(tempDir, 'ordered_config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            zebra: { command: 'z' },
+            alpha: { command: 'a' },
+            middle: { url: 'https://example.com' },
+          },
+        })
+      );
+
+      const config = await loadConfig(configPath);
+      expect(listServerNames(config)).toEqual(['zebra', 'alpha', 'middle']);
+    });
   });
 
   describe('type guards', () => {


### PR DESCRIPTION
$## Summary\n- add regression coverage for `listServerNames()` preserving declaration order\n- lock the current CLI-facing enumeration behavior so server names are not silently re-sorted\n\n## Testing\n- bun test tests/config.test.ts -t "preserves declaration order"\n- bun run typecheck\n- git diff --check