### PR TITLE
test: cover unknown server error details

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -204,6 +204,25 @@ describe('config', () => {
       const config = await loadConfig(configPath);
       expect(() => getServerConfig(config, 'unknown')).toThrow('not found');
     });
+
+    test('includes the requested name and available servers in unknown-server errors', async () => {
+      const configPath = join(tempDir, 'multi_server_config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            alpha: { command: 'cmd-a' },
+            beta: { command: 'cmd-b' },
+          },
+        })
+      );
+
+      const config = await loadConfig(configPath);
+
+      expect(() => getServerConfig(config, 'missing')).toThrow('missing');
+      expect(() => getServerConfig(config, 'missing')).toThrow('alpha');
+      expect(() => getServerConfig(config, 'missing')).toThrow('beta');
+    });
   });
 
   describe('listServerNames', () => {


### PR DESCRIPTION
$## Summary\n- add regression coverage for unknown-server errors including the requested name\n- assert the formatted error also includes the available server list so the CLI keeps its current helpful diagnostic detail\n\n## Testing\n- bun test tests/config.test.ts -t "includes the requested name and available servers in unknown-server errors"\n- bun run typecheck\n- git diff --check