### PR TITLE
test: cover tool filter contracts

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -7,11 +7,12 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  loadConfig,
   getServerConfig,
-  listServerNames,
   isHttpServer,
   isStdioServer,
+  isToolAllowed,
+  listServerNames,
+  loadConfig,
 } from '../src/config';
 
 describe('config', () => {
@@ -238,6 +239,29 @@ describe('config', () => {
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
+    });
+  });
+
+  describe('tool filtering', () => {
+    test('treats an empty allowedTools list as no allow filter', () => {
+      const serverConfig = {
+        command: 'echo',
+        allowedTools: [],
+      } as any;
+
+      expect(isToolAllowed('read_file', serverConfig)).toBe(true);
+      expect(isToolAllowed('write_file', serverConfig)).toBe(true);
+    });
+
+    test('disabledTools takes precedence over allowedTools', () => {
+      const serverConfig = {
+        command: 'echo',
+        allowedTools: ['read_*', 'write_*'],
+        disabledTools: ['write_*'],
+      } as any;
+
+      expect(isToolAllowed('read_file', serverConfig)).toBe(true);
+      expect(isToolAllowed('write_file', serverConfig)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
$## Summary\n- add regression coverage for `allowedTools: []` behaving like no allow filter instead of denying all tools\n- add regression coverage for `disabledTools` continuing to take precedence over `allowedTools`\n\n## Testing\n- bun test tests/config.test.ts -t "treats an empty allowedTools list as no allow filter|disabledTools takes precedence over allowedTools"\n- bun run typecheck\n- git diff --check