### PR TITLE
test: cover empty disabledTools semantics

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -7,11 +7,12 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  loadConfig,
   getServerConfig,
-  listServerNames,
   isHttpServer,
   isStdioServer,
+  isToolAllowed,
+  listServerNames,
+  loadConfig,
 } from '../src/config';
 
 describe('config', () => {
@@ -238,6 +239,18 @@ describe('config', () => {
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
+    });
+  });
+
+  describe('tool filtering', () => {
+    test('treats an empty disabledTools list as no deny filter', () => {
+      const serverConfig = {
+        command: 'echo',
+        disabledTools: [],
+      } as any;
+
+      expect(isToolAllowed('read_file', serverConfig)).toBe(true);
+      expect(isToolAllowed('write_file', serverConfig)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
$## Summary\n- add regression coverage for `disabledTools: []` behaving like no deny filter\n- lock the empty-array edge case so tool filtering does not accidentally broaden into deny-all behavior\n\n## Testing\n- bun test tests/config.test.ts -t "treats an empty disabledTools list as no deny filter"\n- bun run typecheck\n- git diff --check