### PR TITLE
test: cover transport type guard contract

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -235,9 +235,32 @@ describe('config', () => {
       expect(isHttpServer({ command: 'echo' })).toBe(false);
     });
 
+    test('isHttpServer still identifies HTTP configs when extra fields are present', () => {
+      expect(
+        isHttpServer({
+          url: 'https://example.com',
+          headers: { Authorization: 'Bearer token' },
+          timeout: 10,
+          allowedTools: ['read_*'],
+        } as any)
+      ).toBe(true);
+    });
+
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
+    });
+
+    test('isStdioServer still identifies stdio configs when extra fields are present', () => {
+      expect(
+        isStdioServer({
+          command: 'echo',
+          args: ['hello'],
+          env: { DEBUG: '1' },
+          cwd: '/tmp/mcp',
+          disabledTools: ['write_*'],
+        } as any)
+      ).toBe(true);
     });
   });
 });


### PR DESCRIPTION
$## Summary\n- add regression coverage for `isHttpServer()` continuing to identify HTTP configs when extra HTTP fields are present\n- add regression coverage for `isStdioServer()` continuing to identify stdio configs when extra stdio fields are present\n- lock the discriminator contract so transport type guards do not start depending on unrelated optional fields\n\n## Testing\n- bun test tests/config.test.ts -t "isHttpServer still identifies HTTP configs when extra fields are present|isStdioServer still identifies stdio configs when extra fields are present"\n- bun run typecheck\n- git diff --check