### PR TITLE
test: cover default tool filter behavior

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -7,11 +7,12 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  loadConfig,
   getServerConfig,
-  listServerNames,
   isHttpServer,
   isStdioServer,
+  isToolAllowed,
+  listServerNames,
+  loadConfig,
 } from '../src/config';
 
 describe('config', () => {
@@ -238,6 +239,18 @@ describe('config', () => {
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
+    });
+  });
+
+  describe('tool filtering', () => {
+    test('allows tools by default when no allow or deny filters are configured', () => {
+      const serverConfig = {
+        command: 'echo',
+      } as any;
+
+      expect(isToolAllowed('read_file', serverConfig)).toBe(true);
+      expect(isToolAllowed('write_file', serverConfig)).toBe(true);
+      expect(isToolAllowed('custom_tool', serverConfig)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
$## Summary\n- add regression coverage for `isToolAllowed()` defaulting to allow-all when no tool filters are configured\n- lock the default behavior so future filtering changes do not silently tighten the baseline into deny-by-default\n\n## Testing\n- bun test tests/config.test.ts -t "allows tools by default when no allow or deny filters are configured"\n- bun run typecheck\n- git diff --check