### PR TITLE
test: cover getServerConfig reference contract

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -192,6 +192,22 @@ describe('config', () => {
       expect((server as any).command).toBe('cmd1');
     });
 
+    test('returns the same server object reference stored in config', async () => {
+      const configPath = join(tempDir, 'reference_config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            server1: { command: 'cmd1', args: ['hello'] },
+          },
+        })
+      );
+
+      const config = await loadConfig(configPath);
+      const server = getServerConfig(config, 'server1');
+      expect(server).toBe(config.mcpServers.server1);
+    });
+
     test('throws on unknown server', async () => {
       const configPath = join(tempDir, 'config.json');
       await writeFile(


### PR DESCRIPTION
$## Summary\n- add regression coverage for `getServerConfig()` returning the same server object reference stored in `config.mcpServers`\n- lock the current helper contract so future refactors do not silently switch it to cloning behavior\n\n## Testing\n- bun test tests/config.test.ts -t "returns the same server object reference stored in config"\n- bun run typecheck\n- git diff --check