### PR TITLE
test: cover listServerNames return independence

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -227,6 +227,26 @@ describe('config', () => {
       expect(names).toContain('gamma');
       expect(names.length).toBe(3);
     });
+
+    test('returns an array that can be mutated without affecting config keys', async () => {
+      const configPath = join(tempDir, 'mutable_names_config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            alpha: { command: 'a' },
+            beta: { command: 'b' },
+          },
+        })
+      );
+
+      const config = await loadConfig(configPath);
+      const names = listServerNames(config);
+      names.pop();
+
+      expect(Object.keys(config.mcpServers)).toEqual(['alpha', 'beta']);
+      expect(listServerNames(config)).toEqual(['alpha', 'beta']);
+    });
   });
 
   describe('type guards', () => {


### PR DESCRIPTION
$## Summary\n- add regression coverage for `listServerNames()` returning a standalone array that can be mutated by callers without affecting the underlying config\n- lock the helper behavior so future refactors do not accidentally expose a shared mutable structure\n\n## Testing\n- bun test tests/config.test.ts -t "returns an array that can be mutated without affecting config keys"\n- bun run typecheck\n- git diff --check