### PR TITLE
test: cover getServerConfig live reference behavior

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -192,6 +192,24 @@ describe('config', () => {
       expect((server as any).command).toBe('cmd1');
     });
 
+    test('returns a live server reference that mutates the underlying config', async () => {
+      const configPath = join(tempDir, 'live_reference_config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            server1: { command: 'cmd1' },
+          },
+        })
+      );
+
+      const config = await loadConfig(configPath);
+      const server = getServerConfig(config, 'server1') as any;
+      server.command = 'patched-cmd';
+
+      expect((config.mcpServers.server1 as any).command).toBe('patched-cmd');
+    });
+
     test('throws on unknown server', async () => {
       const configPath = join(tempDir, 'config.json');
       await writeFile(


### PR DESCRIPTION
$## Summary\n- add regression coverage for `getServerConfig()` returning a live reference into `config.mcpServers`\n- lock the current mutation behavior so refactors do not silently change this helper into a detached copy\n\n## Testing\n- bun test tests/config.test.ts -t "returns a live server reference that mutates the underlying config"\n- bun run typecheck\n- git diff --check