### PR TITLE
test: cover unknown server errors for empty configs

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -204,6 +204,20 @@ describe('config', () => {
       const config = await loadConfig(configPath);
       expect(() => getServerConfig(config, 'unknown')).toThrow('not found');
     });
+
+    test('throws a stable unknown-server error when no servers are configured', async () => {
+      const configPath = join(tempDir, 'empty_config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {},
+        })
+      );
+
+      const config = await loadConfig(configPath);
+      expect(() => getServerConfig(config, 'unknown')).toThrow('unknown');
+      expect(() => getServerConfig(config, 'unknown')).toThrow('not found');
+    });
   });
 
   describe('listServerNames', () => {


### PR DESCRIPTION
$## Summary\n- add regression coverage for `getServerConfig()` when the config has no servers at all\n- lock the zero-server edge case so unknown-server lookups still produce a stable error instead of throwing something unexpected\n\n## Testing\n- bun test tests/config.test.ts -t "throws a stable unknown-server error when no servers are configured"\n- bun run typecheck\n- git diff --check