### PR TITLE
test: cover empty mcpServers behavior

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -61,6 +61,19 @@ describe('config', () => {
       await expect(loadConfig(configPath)).rejects.toThrow('mcpServers');
     });
 
+    test('allows an empty mcpServers object', async () => {
+      const configPath = join(tempDir, 'empty_servers.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {},
+        })
+      );
+
+      const config = await loadConfig(configPath);
+      expect(config.mcpServers).toEqual({});
+    });
+
     test('substitutes environment variables', async () => {
       process.env.TEST_MCP_TOKEN = 'secret123';
 


### PR DESCRIPTION
$## Summary\n- add regression coverage for `loadConfig()` accepting an empty `mcpServers` object\n- lock the current behavior so an empty-but-valid config stays a warning path instead of becoming a hard validation error\n\n## Testing\n- bun test tests/config.test.ts -t "allows an empty mcpServers object"\n- bun run typecheck\n- git diff --check