### PR TITLE
test: cover empty filterTools input

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -7,11 +7,12 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  loadConfig,
+  filterTools,
   getServerConfig,
-  listServerNames,
   isHttpServer,
   isStdioServer,
+  listServerNames,
+  loadConfig,
 } from '../src/config';
 
 describe('config', () => {
@@ -238,6 +239,14 @@ describe('config', () => {
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
+    });
+  });
+
+  describe('filterTools', () => {
+    test('returns an empty array when given no tools', () => {
+      const config = { command: 'echo', allowedTools: ['read_*'] } as any;
+
+      expect(filterTools([], config)).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
$## Summary\n- add regression coverage for `filterTools()` receiving an empty tool list\n- lock the zero-input edge case so tool filtering remains a stable empty-array pass-through\n\n## Testing\n- bun test tests/config.test.ts -t "returns an empty array when given no tools"\n- bun run typecheck\n- git diff --check