### PR TITLE
test: cover single-character wildcard in disabledTools patterns

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -7,11 +7,12 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  loadConfig,
+  filterTools,
   getServerConfig,
-  listServerNames,
   isHttpServer,
   isStdioServer,
+  listServerNames,
+  loadConfig,
 } from '../src/config';
 
 describe('config', () => {
@@ -238,6 +239,23 @@ describe('config', () => {
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
+    });
+  });
+
+  describe('filterTools', () => {
+    test('treats ? as a single-character wildcard in disabledTools patterns', () => {
+      const config = { command: 'echo', disabledTools: ['read_?ile'] } as any;
+      const tools = [
+        { name: 'read_file' },
+        { name: 'read_xile' },
+        { name: 'read_profile' },
+      ];
+
+      // disabledTools should deny read_file and read_xile (single char match)
+      // but allow read_profile (double char where ? only matches one)
+      expect(filterTools(tools, config).map((tool) => tool.name)).toEqual([
+        'read_profile',
+      ]);
     });
   });
 });


### PR DESCRIPTION
$## Summary\n- add regression coverage for `?` in disabledTools filter patterns acting as a single-character wildcard\n- lock the deny-list matcher semantics so future changes do not accidentally broaden `?` into multi-character matching\n\n## Testing\n- bun test tests/config.test.ts -t "disabledTools patterns"\n- bun run typecheck\n- git diff --check