### PR TITLE
test: cover regex special character escaping in tool patterns

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -7,11 +7,12 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  loadConfig,
+  filterTools,
   getServerConfig,
-  listServerNames,
   isHttpServer,
   isStdioServer,
+  listServerNames,
+  loadConfig,
 } from '../src/config';
 
 describe('config', () => {
@@ -238,6 +239,22 @@ describe('config', () => {
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
+    });
+  });
+
+  describe('filterTools', () => {
+    test('escapes regex special characters in patterns as literals', () => {
+      const config = { command: 'echo', allowedTools: ['read.file'] } as any;
+      const tools = [
+        { name: 'read.file' },
+        { name: 'readXfile' },
+        { name: 'read_file' },
+      ];
+
+      // Pattern 'read.file' should be treated as literal dot, not regex "any char"
+      expect(filterTools(tools, config).map((tool) => tool.name)).toEqual([
+        'read.file',
+      ]);
     });
   });
 });


### PR DESCRIPTION
$## Summary\n- add regression coverage for regex special character escaping in tool filter patterns\n- lock the current behavior so literal dots (and other regex meta-chars) in patterns are treated as literals, not as regex wildcards\n\n## Testing\n- bun test tests/config.test.ts -t "escapes regex special characters in patterns as literals"\n- bun run typecheck\n- git diff --check