### PR TITLE
test: cover case-insensitive pattern matching in tool filters

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -7,11 +7,12 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  loadConfig,
+  filterTools,
   getServerConfig,
-  listServerNames,
   isHttpServer,
   isStdioServer,
+  listServerNames,
+  loadConfig,
 } from '../src/config';
 
 describe('config', () => {
@@ -238,6 +239,25 @@ describe('config', () => {
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
+    });
+  });
+
+  describe('filterTools', () => {
+    test('matches patterns case-insensitively', () => {
+      const config = { command: 'echo', allowedTools: ['READ_*'] } as any;
+      const tools = [
+        { name: 'read_file' },
+        { name: 'READ_FILE' },
+        { name: 'Read_File' },
+        { name: 'write_file' },
+      ];
+
+      // All case variants of read_* should match
+      expect(filterTools(tools, config).map((tool) => tool.name)).toEqual([
+        'read_file',
+        'READ_FILE',
+        'Read_File',
+      ]);
     });
   });
 });


### PR DESCRIPTION
$## Summary\n- add regression coverage for case-insensitive tool pattern matching\n- lock the current behavior so patterns like READ_* match read_file, READ_FILE, and Read_File\n\n## Testing\n- bun test tests/config.test.ts -t "matches patterns case-insensitively"\n- bun run typecheck\n- git diff --check