### PR TITLE
test: cover empty string env var substitution

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -7,11 +7,12 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  loadConfig,
+  filterTools,
   getServerConfig,
-  listServerNames,
   isHttpServer,
   isStdioServer,
+  listServerNames,
+  loadConfig,
 } from '../src/config';
 
 describe('config', () => {
@@ -238,6 +239,32 @@ describe('config', () => {
     test('isStdioServer identifies stdio config', () => {
       expect(isStdioServer({ command: 'echo' })).toBe(true);
       expect(isStdioServer({ url: 'https://example.com' })).toBe(false);
+    });
+  });
+
+  describe('env var substitution', () => {
+    test('substitutes empty string env vars without error', async () => {
+      process.env.TEST_EMPTY_VAR = '';
+
+      const configPath = join(tempDir, 'empty_env.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            test: {
+              command: 'echo',
+              args: ['${TEST_EMPTY_VAR}'],
+            },
+          },
+        })
+      );
+
+      const config = await loadConfig(configPath);
+      const server = config.mcpServers.test as any;
+      // Empty string should be substituted, not treated as missing
+      expect(server.args[0]).toBe('');
+
+      delete process.env.TEST_EMPTY_VAR;
     });
   });
 });


### PR DESCRIPTION
$## Summary\n- add regression coverage for env var substitution when the variable is set to an empty string\n- lock the behavior so empty string values are substituted correctly, not treated as missing variables\n\n## Testing\n- bun test tests/config.test.ts -t "substitutes empty string env vars without error"\n- bun run typecheck\n- git diff --check