### PR TITLE
test: cover empty MCP_STRICT_ENV semantics

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -108,6 +108,27 @@ describe('config', () => {
       delete process.env.MCP_STRICT_ENV;
     });
 
+    test('treats empty MCP_STRICT_ENV as strict mode', async () => {
+      process.env.MCP_STRICT_ENV = '';
+
+      const configPath = join(tempDir, 'missing_env_empty_strict.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            test: {
+              command: 'echo',
+              env: { TOKEN: '${NONEXISTENT_VAR}' },
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Missing environment variable');
+
+      delete process.env.MCP_STRICT_ENV;
+    });
+
     test('throws error on missing env vars in strict mode (default)', async () => {
       // Ensure strict mode is enabled (default)
       delete process.env.MCP_STRICT_ENV;


### PR DESCRIPTION
$## Summary\n- add regression coverage for `MCP_STRICT_ENV` being set to an empty string\n- lock the boundary so only `false` and `0` disable strict mode, while empty values still keep strict validation enabled\n\n## Testing\n- bun test tests/config.test.ts -t "treats empty MCP_STRICT_ENV as strict mode"\n- bun run typecheck\n- git diff --check