### PR TITLE
test: cover whitespace-padded MCP_STRICT_ENV semantics

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -108,6 +108,27 @@ describe('config', () => {
       delete process.env.MCP_STRICT_ENV;
     });
 
+    test('treats whitespace-padded false as strict mode', async () => {
+      process.env.MCP_STRICT_ENV = ' false ';
+
+      const configPath = join(tempDir, 'missing_env_whitespace_strict.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            test: {
+              command: 'echo',
+              env: { TOKEN: '${NONEXISTENT_VAR}' },
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Missing environment variable');
+
+      delete process.env.MCP_STRICT_ENV;
+    });
+
     test('throws error on missing env vars in strict mode (default)', async () => {
       // Ensure strict mode is enabled (default)
       delete process.env.MCP_STRICT_ENV;


### PR DESCRIPTION
$## Summary\n- add regression coverage for `MCP_STRICT_ENV` values with surrounding whitespace\n- lock the current boundary so only the exact normalized values `false` and `0` disable strict mode, while whitespace-padded variants stay strict\n\n## Testing\n- bun test tests/config.test.ts -t "treats whitespace-padded false as strict mode"\n- bun run typecheck\n- git diff --check