### PR TITLE
test: cover MCP_STRICT_ENV=00 semantics

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -108,6 +108,27 @@ describe('config', () => {
       delete process.env.MCP_STRICT_ENV;
     });
 
+    test('treats MCP_STRICT_ENV=00 as strict mode', async () => {
+      process.env.MCP_STRICT_ENV = '00';
+
+      const configPath = join(tempDir, 'missing_env_double_zero.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            test: {
+              command: 'echo',
+              env: { TOKEN: '${NONEXISTENT_VAR}' },
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Missing environment variable');
+
+      delete process.env.MCP_STRICT_ENV;
+    });
+
     test('throws error on missing env vars in strict mode (default)', async () => {
       // Ensure strict mode is enabled (default)
       delete process.env.MCP_STRICT_ENV;


### PR DESCRIPTION
$## Summary\n- add regression coverage for `MCP_STRICT_ENV=00`\n- lock the boundary so only the exact value `0` disables strict mode, while lookalikes like `00` still keep strict validation enabled\n\n## Testing\n- bun test tests/config.test.ts -t "treats MCP_STRICT_ENV=00 as strict mode"\n- bun run typecheck\n- git diff --check