### PR TITLE
test: cover MCP_STRICT_ENV trailing-space zero semantics

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -108,6 +108,27 @@ describe('config', () => {
       delete process.env.MCP_STRICT_ENV;
     });
 
+    test('treats MCP_STRICT_ENV with trailing-space zero as strict mode', async () => {
+      process.env.MCP_STRICT_ENV = '0 ';
+
+      const configPath = join(tempDir, 'missing_env_zero_trailing_space.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            test: {
+              command: 'echo',
+              env: { TOKEN: '${NONEXISTENT_VAR}' },
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Missing environment variable');
+
+      delete process.env.MCP_STRICT_ENV;
+    });
+
     test('throws error on missing env vars in strict mode (default)', async () => {
       // Ensure strict mode is enabled (default)
       delete process.env.MCP_STRICT_ENV;


### PR DESCRIPTION
$## Summary\n- add regression coverage for `MCP_STRICT_ENV` values with trailing whitespace after `0`\n- lock the boundary so only the exact value `0` disables strict mode, while `0 ` still keeps strict validation enabled\n\n## Testing\n- bun test tests/config.test.ts -t "trailing-space zero as strict mode"\n- bun run typecheck\n- git diff --check