### PR TITLE
test: cover MCP_STRICT_ENV false-with-trailing-tab semantics

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -108,6 +108,27 @@ describe('config', () => {
       delete process.env.MCP_STRICT_ENV;
     });
 
+    test('treats MCP_STRICT_ENV with trailing-tab false as strict mode', async () => {
+      process.env.MCP_STRICT_ENV = 'FALSE\t';
+
+      const configPath = join(tempDir, 'missing_env_false_trailing_tab.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            test: {
+              command: 'echo',
+              env: { TOKEN: '${NONEXISTENT_VAR}' },
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Missing environment variable');
+
+      delete process.env.MCP_STRICT_ENV;
+    });
+
     test('throws error on missing env vars in strict mode (default)', async () => {
       // Ensure strict mode is enabled (default)
       delete process.env.MCP_STRICT_ENV;


### PR DESCRIPTION
$## Summary\n- add regression coverage for `MCP_STRICT_ENV` values like `FALSE\t` with trailing tabs\n- lock the boundary so tab-padded variants still keep strict validation enabled instead of silently flipping to warning-only mode\n\n## Testing\n- bun test tests/config.test.ts -t "trailing-tab false as strict mode"\n- bun run typecheck\n- git diff --check