### PR TITLE
test: cover MCP_STRICT_ENV mixed-case false-with-tabs semantics

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -108,6 +108,27 @@ describe('config', () => {
       delete process.env.MCP_STRICT_ENV;
     });
 
+    test('treats MCP_STRICT_ENV with surrounding-tab mixed-case false as strict mode', async () => {
+      process.env.MCP_STRICT_ENV = '\tFalse\t';
+
+      const configPath = join(tempDir, 'missing_env_false_mixed_surrounded_tabs.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            test: {
+              command: 'echo',
+              env: { TOKEN: '${NONEXISTENT_VAR}' },
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Missing environment variable');
+
+      delete process.env.MCP_STRICT_ENV;
+    });
+
     test('throws error on missing env vars in strict mode (default)', async () => {
       // Ensure strict mode is enabled (default)
       delete process.env.MCP_STRICT_ENV;


### PR DESCRIPTION
$## Summary\n- add regression coverage for `MCP_STRICT_ENV` values like `\tFalse\t` with surrounding tabs\n- lock the boundary so mixed-case false variants padded with tabs still keep strict validation enabled instead of silently flipping to warning-only mode\n\n## Testing\n- bun test tests/config.test.ts -t "surrounding-tab mixed-case false as strict mode"\n- bun run typecheck\n- git diff --check