### PR TITLE
test: cover MCP_STRICT_ENV false-with-surrounding-CRLF semantics

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -108,6 +108,28 @@ describe('config', () => {
       delete process.env.MCP_STRICT_ENV;
     });
 
+
+    test('treats MCP_STRICT_ENV with surrounding-CRLF false as strict mode', async () => {
+      process.env.MCP_STRICT_ENV = '\r\nfalse\r\n';
+
+      const configPath = join(tempDir, 'missing_env_false_surrounded_crlf.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            test: {
+              command: 'echo',
+              env: { TOKEN: '${NONEXISTENT_VAR}' },
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Missing environment variable');
+
+      delete process.env.MCP_STRICT_ENV;
+    });
+
     test('throws error on missing env vars in strict mode (default)', async () => {
       // Ensure strict mode is enabled (default)
       delete process.env.MCP_STRICT_ENV;


### PR DESCRIPTION
## Summary\n- add regression coverage for  values wrapped in CRLF line endings\n- lock the current behavior so  does not silently disable strict mode\n\n## Testing\n- /home/node/.bun/bin/bun test tests/config.test.ts -t 'surrounding-CRLF false as strict mode'\n- /home/node/.bun/bin/bun run typecheck\n- git diff --check