### PR TITLE
test: cover MCP_STRICT_ENV trailing-space zero-with-surrounding-CRLF semantics

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -108,6 +108,28 @@ describe('config', () => {
       delete process.env.MCP_STRICT_ENV;
     });
 
+
+    test('treats MCP_STRICT_ENV with surrounding-CRLF trailing-space zero as strict mode', async () => {
+      process.env.MCP_STRICT_ENV = '\r\n0 \r\n';
+
+      const configPath = join(tempDir, 'missing_env_trailing_space_zero_surrounded_crlf.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            test: {
+              command: 'echo',
+              env: { TOKEN: '${NONEXISTENT_VAR}' },
+            },
+          },
+        })
+      );
+
+      await expect(loadConfig(configPath)).rejects.toThrow('Missing environment variable');
+
+      delete process.env.MCP_STRICT_ENV;
+    });
+
     test('throws error on missing env vars in strict mode (default)', async () => {
       // Ensure strict mode is enabled (default)
       delete process.env.MCP_STRICT_ENV;


### PR DESCRIPTION
## Summary
- add regression coverage for trailing-space numeric `MCP_STRICT_ENV` values wrapped in CRLF line endings
- lock the current behavior so `\r\n0 \r\n` does not silently disable strict mode

## Testing
- /home/node/.bun/bin/bun test tests/config.test.ts -t 'surrounding-CRLF trailing-space zero as strict mode'
- /home/node/.bun/bin/bun run typecheck
- git diff --check
