### PR TITLE
fix: publish linux arm64 release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Build Linux x64
         run: bun build --compile --minify --target=bun-linux-x64 src/index.ts --outfile dist/mcp-cli-linux-x64
       
+      - name: Build Linux ARM64
+        run: bun build --compile --minify --target=bun-linux-arm64 src/index.ts --outfile dist/mcp-cli-linux-arm64
+      
       - name: Build macOS x64
         run: bun build --compile --minify --target=bun-darwin-x64 src/index.ts --outfile dist/mcp-cli-darwin-x64
       
@@ -95,6 +98,7 @@ jobs:
           generate_release_notes: true
           files: |
             dist/mcp-cli-linux-x64
+            dist/mcp-cli-linux-arm64
             dist/mcp-cli-darwin-x64
             dist/mcp-cli-darwin-arm64
             dist/checksums.txt


### PR DESCRIPTION
## Summary
- add the missing Linux ARM64 build step to the release workflow
- upload `dist/mcp-cli-linux-arm64` with the other release binaries
- align GitHub Releases with `install.sh`, which already downloads the ARM64 asset on linux/aarch64

## Validation
- verified the workflow now includes both the build step and uploaded file entry for `dist/mcp-cli-linux-arm64`

Closes #24.
