### PR TITLE
fix: daemon IPC drops large payloads and callTool uses wrong timeout

### DIFF
--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -12,6 +12,7 @@ import {
   getConfigHash,
   getSocketDir,
   getSocketPath,
+  getTimeoutMs,
 } from './config.js';
 import {
   type DaemonRequest,
@@ -49,13 +50,30 @@ function generateRequestId(): string {
 }
 
 /**
- * Send a request to the daemon and wait for response
+ * Default timeout for quick IPC requests (ping, listTools, etc.)
+ */
+const DEFAULT_IPC_TIMEOUT_MS = 5000;
+
+/**
+ * Send a request to the daemon and wait for response.
+ *
+ * The daemon closes the connection after writing the full response,
+ * so we buffer all incoming data and parse on connection close.
+ *
+ * @param socketPath - Unix socket path for daemon IPC
+ * @param request - The daemon request to send
+ * @param timeoutMs - Timeout in milliseconds (default: 5000 for quick IPC,
+ *                    use getTimeoutMs() for tool execution)
  */
 async function sendRequest(
   socketPath: string,
   request: DaemonRequest,
+  timeoutMs: number = DEFAULT_IPC_TIMEOUT_MS,
 ): Promise<DaemonResponse> {
   return new Promise((resolve, reject) => {
+    let buffer = '';
+    let settled = false;
+
     const socket = Bun.connect({
       unix: socketPath,
       socket: {
@@ -63,31 +81,43 @@ async function sendRequest(
           socket.write(JSON.stringify(request));
         },
         data(socket, data) {
-          try {
-            const response = JSON.parse(data.toString().trim());
-            socket.end();
-            resolve(response);
-          } catch (err) {
-            socket.end();
-            reject(new Error('Invalid response from daemon'));
-          }
+          if (settled) return;
+          buffer += data.toString();
         },
         error(socket, error) {
-          reject(error);
+          if (!settled) {
+            settled = true;
+            reject(error);
+          }
         },
         close() {
-          // Connection closed
+          // Daemon closes the connection after writing the full response
+          if (!settled && buffer.length > 0) {
+            try {
+              const response = JSON.parse(buffer.trim());
+              settled = true;
+              resolve(response);
+            } catch {
+              settled = true;
+              reject(new Error('Invalid response from daemon'));
+            }
+          }
         },
         connectError(socket, error) {
-          reject(error);
+          if (!settled) {
+            settled = true;
+            reject(error);
+          }
         },
       },
     });
 
-    // Timeout after 5 seconds (fast fallback to direct connection)
     setTimeout(() => {
-      reject(new Error('Daemon request timeout'));
-    }, 5000);
+      if (!settled) {
+        settled = true;
+        reject(new Error('Daemon request timeout'));
+      }
+    }, timeoutMs);
   });
 }
 
@@ -286,12 +316,16 @@ export async function getDaemonConnection(
       toolName: string,
       args: Record<string, unknown>,
     ): Promise<unknown> {
-      const response = await sendRequest(socketPath, {
-        id: generateRequestId(),
-        type: 'callTool',
-        toolName,
-        args,
-      });
+      const response = await sendRequest(
+        socketPath,
+        {
+          id: generateRequestId(),
+          type: 'callTool',
+          toolName,
+          args,
+        },
+        getTimeoutMs(),
+      );
 
       if (!response.success) {
         throw new Error(response.error?.message ?? 'callTool failed');

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -357,7 +357,19 @@ export async function runDaemon(
         },
         async data(socket, data) {
           const response = await handleRequest(data);
-          socket.write(`${JSON.stringify(response)}\n`);
+          const payload = `${JSON.stringify(response)}\n`;
+          // Write in chunks to handle large payloads that exceed socket buffer
+          let offset = 0;
+          while (offset < payload.length) {
+            const written = socket.write(payload.slice(offset));
+            if (written === 0) {
+              await new Promise((r) => setTimeout(r, 1));
+              continue;
+            }
+            offset += written;
+          }
+          socket.flush();
+          socket.end();
         },
         close(socket) {
           activeConnections.delete(socket);


### PR DESCRIPTION
## Problem

Two bugs in daemon mode that surface when MCP tools return large responses (e.g. browser automation snapshots of complex pages like GitHub):

### 1. Large socket payloads are silently truncated

`socket.write()` in Bun's Unix socket may not send all data at once when the payload exceeds the socket buffer size (~8KB). The original code does a single `socket.write()` and assumes it completes, but for large tool responses only the first chunk arrives at the client.

The client then tries to `JSON.parse()` the partial data and fails with "Invalid response from daemon", or hangs forever waiting for a newline delimiter that never arrives.

### 2. callTool requests use the 5s IPC timeout

`sendRequest()` has a hardcoded 5-second timeout designed for fast IPC fallback (ping, listTools). But `callTool` also goes through `sendRequest()`, so any tool execution taking >5s (e.g. browser navigation waiting for page load) times out with "Daemon request timeout" and falls back to a direct connection — defeating the purpose of the daemon.

## Fix

**daemon.ts**: Write response payload in a loop to handle partial writes, then `flush()` and `end()` the socket connection.

**daemon-client.ts**:
- Add a configurable `timeoutMs` parameter to `sendRequest()` (default 5s for quick IPC)
- `callTool` passes `getTimeoutMs()` (respects `MCP_TIMEOUT` env var, default 30 min)
- Buffer all incoming data chunks and parse on connection close (instead of relying on newline delimiter)
- Guard against double-resolve with a `settled` flag

## Testing

Verified end-to-end with BrowserMCP (`@browsermcp/mcp`) which returns ~8-30KB accessibility snapshots:
- `browser_snapshot` on GitHub.com: was hanging forever, now returns in ~2s
- `browser_navigate`: was timing out at 5s, now completes normally
- `ping` / `listTools`: still fast (<100ms), unaffected by the change
