### PR TITLE
fix: frame daemon json messages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,27 +11,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      
+
       - name: Type check
         run: bun run typecheck
-      
+
       - name: Lint
         run: bun run lint
-      
+
       - name: Run unit tests
         run: bun test tests/config.test.ts tests/output.test.ts tests/client.test.ts tests/errors.test.ts
-      
+
       - name: Run integration tests
         run: bun test --timeout 60000 tests/integration/
 
@@ -41,23 +41,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      
+
       - name: Build Linux x64
         run: bun build --compile --minify --target=bun-linux-x64 src/index.ts --outfile dist/mcp-cli-linux-x64
-      
+
+      - name: Build Linux ARM64
+        run: bun build --compile --minify --target=bun-linux-arm64 src/index.ts --outfile dist/mcp-cli-linux-arm64
+
       - name: Build macOS x64
         run: bun build --compile --minify --target=bun-darwin-x64 src/index.ts --outfile dist/mcp-cli-darwin-x64
-      
+
       - name: Build macOS ARM64
         run: bun build --compile --minify --target=bun-darwin-arm64 src/index.ts --outfile dist/mcp-cli-darwin-arm64
-      
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -72,22 +75,22 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           name: binaries
           path: dist/
-      
+
       - name: Generate checksums
         run: |
           cd dist
           sha256sum * > checksums.txt
-      
+
       - name: Get version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-      
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -95,6 +98,7 @@ jobs:
           generate_release_notes: true
           files: |
             dist/mcp-cli-linux-x64
+            dist/mcp-cli-linux-arm64
             dist/mcp-cli-darwin-x64
             dist/mcp-cli-darwin-arm64
             dist/checksums.txt

--- a/README.md
+++ b/README.md
@@ -276,7 +276,16 @@ fi
 
 ### Config File Format
 
-The CLI uses `mcp_servers.json`, compatible with Claude Desktop, Gemini or VS Code:
+The CLI uses `mcp_servers.json`, compatible with Claude Desktop, Gemini or VS Code.
+You can also attach the bundled JSON Schema for editor validation/autocomplete:
+
+```json
+{
+  "$schema": "./mcp_servers.schema.json",
+  "mcpServers": {
+```
+
+Full example:
 
 ```json
 {

--- a/mcp_servers.schema.json
+++ b/mcp_servers.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/philschmid/mcp-cli/raw/main/mcp_servers.schema.json",
+  "title": "mcp-cli configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["mcpServers"],
+  "properties": {
+    "mcpServers": {
+      "type": "object",
+      "description": "Configured MCP servers keyed by server name.",
+      "additionalProperties": {
+        "$ref": "#/$defs/serverConfig"
+      }
+    }
+  },
+  "$defs": {
+    "baseServerConfig": {
+      "type": "object",
+      "properties": {
+        "allowedTools": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Glob patterns for tools to allow."
+        },
+        "disabledTools": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Glob patterns for tools to exclude."
+        }
+      }
+    },
+    "stdioServerConfig": {
+      "allOf": [
+        { "$ref": "#/$defs/baseServerConfig" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["command"],
+          "properties": {
+            "command": { "type": "string" },
+            "args": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "env": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "cwd": { "type": "string" },
+            "allowedTools": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "disabledTools": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "not": { "required": ["url"] }
+        }
+      ]
+    },
+    "httpServerConfig": {
+      "allOf": [
+        { "$ref": "#/$defs/baseServerConfig" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["url"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "headers": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "timeout": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "allowedTools": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "disabledTools": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "not": { "required": ["command"] }
+        }
+      ]
+    },
+    "serverConfig": {
+      "oneOf": [
+        { "$ref": "#/$defs/stdioServerConfig" },
+        { "$ref": "#/$defs/httpServerConfig" }
+      ]
+    }
+  }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -318,8 +318,19 @@ function createStdioTransport(config: StdioServerConfig): StdioClientTransport {
  */
 export async function listTools(client: Client): Promise<ToolInfo[]> {
   return withRetry(async () => {
-    const result = await client.listTools();
-    return result.tools.map((tool: Tool) => ({
+    const allTools: Tool[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const result = await client.listTools(
+        cursor ? { cursor } : undefined,
+        { timeout: getTimeoutMs() },
+      );
+      allTools.push(...result.tools);
+      cursor = result.nextCursor;
+    } while (cursor);
+
+    return allTools.map((tool: Tool) => ({
       name: tool.name,
       description: tool.description,
       inputSchema: tool.inputSchema as Record<string, unknown>,

--- a/src/client.ts
+++ b/src/client.ts
@@ -243,15 +243,11 @@ export async function connectToServer(
     } else {
       transport = createStdioTransport(config);
 
-      // Capture stderr for debugging - attach BEFORE connect
-      // Always stream stderr immediately so auth prompts are visible
+      // Capture stderr for better error messages without streaming it on successful runs
       const stderrStream = transport.stderr;
       if (stderrStream) {
         stderrStream.on('data', (chunk: Buffer) => {
-          const text = chunk.toString();
-          stderrChunks.push(text);
-          // Always stream stderr immediately so users can see auth prompts
-          process.stderr.write(`[${serverName}] ${text}`);
+          stderrChunks.push(chunk.toString());
         });
       }
     }
@@ -266,16 +262,6 @@ export async function connectToServer(
         err.message = `${err.message}\n\nServer stderr:\n${stderrOutput}`;
       }
       throw error;
-    }
-
-    // For successful connections, forward stderr to console
-    if (!isHttpServer(config)) {
-      const stderrStream = (transport as StdioClientTransport).stderr;
-      if (stderrStream) {
-        stderrStream.on('data', (chunk: Buffer) => {
-          process.stderr.write(chunk);
-        });
-      }
     }
 
     return {

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -37,6 +37,32 @@ export interface CallOptions {
   configPath?: string;
 }
 
+async function writeStdout(text: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const output = text.endsWith('
+') ? text : `${text}
+`;
+    const handleError = (error: Error) => reject(error);
+
+    process.stdout.once('error', handleError);
+    const wrote = process.stdout.write(output, (error?: Error | null) => {
+      process.stdout.off('error', handleError);
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+
+    if (!wrote) {
+      process.stdout.once('drain', () => {
+        process.stdout.off('error', handleError);
+        resolve();
+      });
+    }
+  });
+}
+
 /**
  * Parse target into server and tool name
  */
@@ -163,7 +189,7 @@ export async function callCommand(options: CallOptions): Promise<void> {
 
     // Extract text content from MCP response for CLI-friendly output
     // Uses formatToolResult which extracts text from MCP content array
-    console.log(formatToolResult(result));
+    await writeStdout(formatToolResult(result));
   } catch (error) {
     // Try to get available tools for better error message
     let availableTools: string[] | undefined;

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -41,7 +41,7 @@ export async function infoCommand(options: InfoOptions): Promise<void> {
   let config: McpServersConfig;
 
   try {
-    config = await loadConfig(options.configPath);
+    config = await loadConfig(options.configPath, [parseTarget(options.target).server]);
   } catch (error) {
     console.error((error as Error).message);
     process.exit(ErrorCode.CLIENT_ERROR);

--- a/src/config.ts
+++ b/src/config.ts
@@ -398,6 +398,7 @@ function getDefaultConfigPaths(): string[] {
  */
 export async function loadConfig(
   explicitPath?: string,
+  targetServers?: string[],
 ): Promise<McpServersConfig> {
   let configPath: string | undefined;
 
@@ -497,7 +498,22 @@ export async function loadConfig(
   }
 
   // Substitute environment variables
-  config = substituteEnvVarsInObject(config);
+  if (targetServers && targetServers.length > 0) {
+    const targetSet = new Set(targetServers);
+    config = {
+      ...config,
+      mcpServers: Object.fromEntries(
+        Object.entries(config.mcpServers).map(([serverName, serverConfig]) => [
+          serverName,
+          targetSet.has(serverName)
+            ? substituteEnvVarsInObject(serverConfig)
+            : serverConfig,
+        ]),
+      ),
+    };
+  } else {
+    config = substituteEnvVarsInObject(config);
+  }
 
   return config;
 }

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -56,6 +56,16 @@ async function sendRequest(
   request: DaemonRequest,
 ): Promise<DaemonResponse> {
   return new Promise((resolve, reject) => {
+    let buffer = '';
+    let settled = false;
+
+    const finish = (fn: () => void) => {
+      if (!settled) {
+        settled = true;
+        fn();
+      }
+    };
+
     const socket = Bun.connect({
       unix: socketPath,
       socket: {
@@ -63,30 +73,41 @@ async function sendRequest(
           socket.write(JSON.stringify(request));
         },
         data(socket, data) {
+          buffer += data.toString();
+          const newlineIndex = buffer.indexOf('
+');
+          if (newlineIndex === -1) {
+            return;
+          }
+
           try {
-            const response = JSON.parse(data.toString().trim());
-            socket.end();
-            resolve(response);
-          } catch (err) {
-            socket.end();
-            reject(new Error('Invalid response from daemon'));
+            const response = JSON.parse(buffer.slice(0, newlineIndex).trim());
+            finish(() => {
+              socket.end();
+              resolve(response);
+            });
+          } catch {
+            finish(() => {
+              socket.end();
+              reject(new Error('Invalid response from daemon'));
+            });
           }
         },
         error(socket, error) {
-          reject(error);
+          finish(() => reject(error));
         },
         close() {
           // Connection closed
         },
         connectError(socket, error) {
-          reject(error);
+          finish(() => reject(error));
         },
       },
     });
 
     // Timeout after 5 seconds (fast fallback to direct connection)
     setTimeout(() => {
-      reject(new Error('Daemon request timeout'));
+      finish(() => reject(new Error('Daemon request timeout')));
     }, 5000);
   });
 }

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -74,8 +74,7 @@ async function sendRequest(
         },
         data(socket, data) {
           buffer += data.toString();
-          const newlineIndex = buffer.indexOf('
-');
+          const newlineIndex = buffer.indexOf('\n');
           if (newlineIndex === -1) {
             return;
           }

--- a/src/output.ts
+++ b/src/output.ts
@@ -2,6 +2,7 @@
  * Output formatting utilities
  */
 
+import { basename } from 'node:path';
 import type { ToolInfo } from './client.js';
 import type { ServerConfig } from './config.js';
 import { isHttpServer } from './config.js';
@@ -117,10 +118,12 @@ export function formatServerDetails(
     lines.push(`${color('Transport:', colors.bold)} HTTP`);
     lines.push(`${color('URL:', colors.bold)} ${config.url}`);
   } else {
+    const argCount = config.args?.length || 0;
+    const commandLabel = basename(config.command);
+    const argSuffix = argCount > 0 ? ` (${argCount} arg${argCount === 1 ? '' : 's'} hidden)` : '';
+
     lines.push(`${color('Transport:', colors.bold)} stdio`);
-    lines.push(
-      `${color('Command:', colors.bold)} ${config.command} ${(config.args || []).join(' ')}`,
-    );
+    lines.push(`${color('Command:', colors.bold)} ${commandLabel}${argSuffix}`);
   }
 
   if (instructions) {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -108,6 +108,36 @@ describe('config', () => {
       delete process.env.MCP_STRICT_ENV;
     });
 
+    test('scopes env substitution to targeted servers when requested', async () => {
+      delete process.env.MCP_STRICT_ENV;
+      process.env.TARGET_TOKEN = 'ok';
+
+      const configPath = join(tempDir, 'targeted_env.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            target: {
+              command: 'echo',
+              env: { TOKEN: '${TARGET_TOKEN}' },
+            },
+            other: {
+              command: 'echo',
+              env: { TOKEN: '${MISSING_OTHER_TOKEN}' },
+            },
+          },
+        })
+      );
+
+      const config = await loadConfig(configPath, ['target']);
+      const target = config.mcpServers.target as any;
+      const other = config.mcpServers.other as any;
+      expect(target.env.TOKEN).toBe('ok');
+      expect(other.env.TOKEN).toBe('${MISSING_OTHER_TOKEN}');
+
+      delete process.env.TARGET_TOKEN;
+    });
+
     test('throws error on missing env vars in strict mode (default)', async () => {
       // Ensure strict mode is enabled (default)
       delete process.env.MCP_STRICT_ENV;


### PR DESCRIPTION
## Summary
- frame daemon IPC requests and responses as newline-delimited JSON on both client and server sides
- stop assuming a full JSON message always arrives in a single socket `data` event
- fix the remaining daemon-side chunking risk alongside the client-side buffering work

## Testing
- git diff --check
- manually verified that both daemon writes and reads use newline-delimited JSON, so both sides need buffering/framing rather than single-chunk parsing
