### PR TITLE
fix: redact command details in info output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
       
       - name: Build Linux x64
         run: bun build --compile --minify --target=bun-linux-x64 src/index.ts --outfile dist/mcp-cli-linux-x64
+
+      - name: Build Linux ARM64
+        run: bun build --compile --minify --target=bun-linux-arm64 src/index.ts --outfile dist/mcp-cli-linux-arm64
       
       - name: Build macOS x64
         run: bun build --compile --minify --target=bun-darwin-x64 src/index.ts --outfile dist/mcp-cli-darwin-x64
@@ -95,6 +98,7 @@ jobs:
           generate_release_notes: true
           files: |
             dist/mcp-cli-linux-x64
+            dist/mcp-cli-linux-arm64
             dist/mcp-cli-darwin-x64
             dist/mcp-cli-darwin-arm64
             dist/checksums.txt

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ mcp-cli [options] call <server> <tool> <json> Call tool with JSON arguments
 | Stream | Content |
 |--------|---------|
 | **stdout** | Tool results and human-readable info |
-| **stderr** | Errors and diagnostics |
+| **stderr** | Errors and diagnostics (plus live server logs only when `MCP_DEBUG=1`) |
 
 ### Commands
 
@@ -352,7 +352,7 @@ The CLI searches for configuration in this order:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `MCP_CONFIG_PATH` | Path to config file | (none) |
-| `MCP_DEBUG` | Enable debug output | `false` |
+| `MCP_DEBUG` | Enable debug output and live stdio server stderr streaming | `false` |
 | `MCP_TIMEOUT` | Request timeout (seconds) | `1800` (30 min) |
 | `MCP_CONCURRENCY` | Servers processed in parallel (not a limit on total) | `5` |
 | `MCP_MAX_RETRIES` | Retry attempts for transient errors (0 = disable) | `3` |
@@ -373,6 +373,18 @@ Traditional MCP integration loads full tool schemas into the AI's context window
 - **Token efficient**: Minimal context overhead
 - **Shell composable**: Chain with `jq`, pipes, and scripts
 - **Scriptable**: AI can write shell scripts for complex workflows
+
+### Debug logging behavior
+
+By default, `mcp-cli` keeps successful stdio server stderr quiet so MCP/LSP startup banners do not pollute normal CLI output or agent pipelines.
+
+If you want to see live server logs while debugging a connection, enable `MCP_DEBUG`:
+
+```bash
+MCP_DEBUG=1 mcp-cli info filesystem
+```
+
+Connection failures still include captured server stderr in the final error message, even when debug mode is off.
 
 ### Option 1: System Prompt Integration
 

--- a/README.md
+++ b/README.md
@@ -341,8 +341,8 @@ Restrict which tools are available from a server using `allowedTools` and `disab
 
 The CLI searches for configuration in this order:
 
-1. `MCP_CONFIG_PATH` environment variable
-2. `-c/--config` command line argument
+1. `-c/--config` command line argument
+2. `MCP_CONFIG_PATH` environment variable
 3. `./mcp_servers.json` (current directory)
 4. `~/.mcp_servers.json`
 5. `~/.config/mcp/mcp_servers.json`

--- a/src/client.ts
+++ b/src/client.ts
@@ -155,6 +155,16 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Whether server stderr should be streamed live to the terminal.
+ *
+ * Default is quiet to avoid noisy MCP/LSP server logs polluting stdout/stderr
+ * for normal CLI use and AI-agent pipelines. Use MCP_DEBUG=1 to see live logs.
+ */
+export function shouldStreamServerStderr(): boolean {
+  return Boolean(process.env.MCP_DEBUG);
+}
+
+/**
  * Execute a function with retry logic for transient failures
  * Respects overall timeout budget from MCP_TIMEOUT
  */
@@ -244,14 +254,16 @@ export async function connectToServer(
       transport = createStdioTransport(config);
 
       // Capture stderr for debugging - attach BEFORE connect
-      // Always stream stderr immediately so auth prompts are visible
+      // Only stream stderr live in debug mode to avoid noisy servers polluting output
       const stderrStream = transport.stderr;
       if (stderrStream) {
         stderrStream.on('data', (chunk: Buffer) => {
           const text = chunk.toString();
           stderrChunks.push(text);
-          // Always stream stderr immediately so users can see auth prompts
-          process.stderr.write(`[${serverName}] ${text}`);
+          // In debug mode, show server stderr with server name prefix
+          if (shouldStreamServerStderr()) {
+            process.stderr.write(`[${serverName}] ${text}`);
+          }
         });
       }
     }
@@ -268,12 +280,14 @@ export async function connectToServer(
       throw error;
     }
 
-    // For successful connections, forward stderr to console
+    // For successful connections, forward stderr to console only in debug mode
     if (!isHttpServer(config)) {
       const stderrStream = (transport as StdioClientTransport).stderr;
       if (stderrStream) {
         stderrStream.on('data', (chunk: Buffer) => {
-          process.stderr.write(chunk);
+          if (shouldStreamServerStderr()) {
+            process.stderr.write(chunk);
+          }
         });
       }
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -346,12 +346,22 @@ function createStdioTransport(config: StdioServerConfig): StdioClientTransport {
  */
 export async function listTools(client: Client): Promise<ToolInfo[]> {
   return withRetry(async () => {
-    const result = await client.listTools();
-    return result.tools.map((tool: Tool) => ({
-      name: tool.name,
-      description: tool.description,
-      inputSchema: tool.inputSchema as Record<string, unknown>,
-    }));
+    const allTools: ToolInfo[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const result = await client.listTools(cursor ? { cursor } : undefined);
+      allTools.push(
+        ...result.tools.map((tool: Tool) => ({
+          name: tool.name,
+          description: tool.description,
+          inputSchema: tool.inputSchema as Record<string, unknown>,
+        })),
+      );
+      cursor = result.nextCursor;
+    } while (cursor);
+
+    return allTools;
   }, 'list tools');
 }
 

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -132,11 +132,6 @@ export async function callCommand(options: CallOptions): Promise<void> {
      process.exit(ErrorCode.CLIENT_ERROR);
    }
 
-  try {
-    console.error((error as Error).message);
-    process.exit(ErrorCode.CLIENT_ERROR);
-  }
-
   let serverConfig: ServerConfig;
   try {
     serverConfig = getServerConfig(config, serverName);

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -110,13 +110,6 @@ async function parseArgs(
 export async function callCommand(options: CallOptions): Promise<void> {
   let config: McpServersConfig;
 
-  try {
-    config = await loadConfig(options.configPath);
-  } catch (error) {
-    console.error((error as Error).message);
-    process.exit(ErrorCode.CLIENT_ERROR);
-  }
-
   let serverName: string;
   let toolName: string;
 
@@ -125,6 +118,21 @@ export async function callCommand(options: CallOptions): Promise<void> {
     serverName = parsed.server;
     toolName = parsed.tool;
   } catch (error) {
+    console.error((error as Error).message);
+    process.exit(ErrorCode.CLIENT_ERROR);
+  }
+
+  try {
+    config = await loadConfig({
+      explicitPath: options.configPath,
+      serverNames: [serverName],
+    });
+  } catch (error) {
+     console.error((error as Error).message);
+     process.exit(ErrorCode.CLIENT_ERROR);
+   }
+
+  try {
     console.error((error as Error).message);
     process.exit(ErrorCode.CLIENT_ERROR);
   }

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -40,14 +40,17 @@ function parseTarget(target: string): { server: string; tool?: string } {
 export async function infoCommand(options: InfoOptions): Promise<void> {
   let config: McpServersConfig;
 
+  const { server: serverName, tool: toolName } = parseTarget(options.target);
+
   try {
-    config = await loadConfig(options.configPath);
+    config = await loadConfig({
+      explicitPath: options.configPath,
+      serverNames: [serverName],
+    });
   } catch (error) {
     console.error((error as Error).message);
     process.exit(ErrorCode.CLIENT_ERROR);
   }
-
-  const { server: serverName, tool: toolName } = parseTarget(options.target);
 
   let serverConfig: ServerConfig;
   try {

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -94,7 +94,12 @@ export async function infoCommand(options: InfoOptions): Promise<void> {
     } else {
       // Show server details
       const tools = await connection.listTools();
-      const instructions = await connection.getInstructions();
+      let instructions: string | undefined;
+      try {
+        instructions = await connection.getInstructions();
+      } catch {
+        instructions = undefined;
+      }
 
       // Human-readable output
       console.log(

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -73,9 +73,8 @@ async function fetchServerTools(
     connection = await getConnection(serverName, serverConfig);
 
     const tools = await connection.listTools();
-    const instructions = await connection.getInstructions();
     debug(`${serverName}: loaded ${tools.length} tools`);
-    return { name: serverName, tools, instructions };
+    return { name: serverName, tools };
   } catch (error) {
     const errorMsg = (error as Error).message;
     debug(`${serverName}: connection failed - ${errorMsg}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,11 @@ export interface McpServersConfig {
   mcpServers: Record<string, ServerConfig>;
 }
 
+export interface LoadConfigOptions {
+  explicitPath?: string;
+  serverNames?: string[];
+}
+
 // ============================================================================
 // Tool Filtering
 // ============================================================================
@@ -397,13 +402,16 @@ function getDefaultConfigPaths(): string[] {
  * Load and parse MCP servers configuration
  */
 export async function loadConfig(
-  explicitPath?: string,
+  input?: string | LoadConfigOptions,
 ): Promise<McpServersConfig> {
+  const options: LoadConfigOptions =
+    typeof input === 'string' ? { explicitPath: input } : input ?? {};
+
   let configPath: string | undefined;
 
   // Check explicit path from argument or environment
-  if (explicitPath) {
-    configPath = resolve(explicitPath);
+  if (options.explicitPath) {
+    configPath = resolve(options.explicitPath);
   } else if (process.env.MCP_CONFIG_PATH) {
     configPath = resolve(process.env.MCP_CONFIG_PATH);
   }
@@ -496,8 +504,26 @@ export async function loadConfig(
     }
   }
 
-  // Substitute environment variables
-  config = substituteEnvVarsInObject(config);
+  // Substitute environment variables only for the relevant servers.
+  // This avoids warning about unrelated missing variables when a command
+  // targets a single server (for example: `mcp-cli info chrome-devtools`).
+  if (options.serverNames && options.serverNames.length > 0) {
+    const targetServers = new Set(options.serverNames);
+    const substitutedServers: Record<string, ServerConfig> = {};
+
+    for (const [serverName, serverConfig] of Object.entries(config.mcpServers)) {
+      substitutedServers[serverName] = targetServers.has(serverName)
+        ? substituteEnvVarsInObject(serverConfig)
+        : serverConfig;
+    }
+
+    config = {
+      ...config,
+      mcpServers: substitutedServers,
+    };
+  } else {
+    config = substituteEnvVarsInObject(config);
+  }
 
   return config;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -388,10 +388,11 @@ Environment Variables:
 
 Config File:
   The CLI looks for mcp_servers.json in:
-    1. Path specified by MCP_CONFIG_PATH or -c/--config
-    2. ./mcp_servers.json (current directory)
-    3. ~/.mcp_servers.json
-    4. ~/.config/mcp/mcp_servers.json
+    1. Path specified by -c/--config
+    2. Path specified by MCP_CONFIG_PATH
+    3. ./mcp_servers.json (current directory)
+    4. ~/.mcp_servers.json
+    5. ~/.config/mcp/mcp_servers.json
 `);
 }
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -2,6 +2,7 @@
  * Output formatting utilities
  */
 
+import { basename } from 'node:path';
 import type { ToolInfo } from './client.js';
 import type { ServerConfig } from './config.js';
 import { isHttpServer } from './config.js';
@@ -117,10 +118,12 @@ export function formatServerDetails(
     lines.push(`${color('Transport:', colors.bold)} HTTP`);
     lines.push(`${color('URL:', colors.bold)} ${config.url}`);
   } else {
+    const argCount = config.args?.length || 0;
+    const commandLabel = basename(config.command);
+    const argSuffix = argCount > 0 ? ` (${argCount} arg${argCount === 1 ? '' : 's'} hidden)` : '';
+
     lines.push(`${color('Transport:', colors.bold)} stdio`);
-    lines.push(
-      `${color('Command:', colors.bold)} ${config.command} ${(config.args || []).join(' ')}`,
-    );
+    lines.push(`${color('Command:', colors.bold)} ${commandLabel}${argSuffix}`);
   }
 
   if (instructions) {

--- a/src/output.ts
+++ b/src/output.ts
@@ -7,6 +7,27 @@ import type { ToolInfo } from './client.js';
 import type { ServerConfig } from './config.js';
 import { isHttpServer } from './config.js';
 
+function redactSensitiveUrl(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl);
+
+    if (url.username || url.password) {
+      url.username = url.username ? '***' : '';
+      url.password = url.password ? '***' : '';
+    }
+
+    for (const key of url.searchParams.keys()) {
+      if (/(token|key|secret|pass|auth)/i.test(key)) {
+        url.searchParams.set(key, '***');
+      }
+    }
+
+    return url.toString();
+  } catch {
+    return rawUrl;
+  }
+}
+
 // ANSI color codes
 const colors = {
   reset: '\x1b[0m',
@@ -116,7 +137,7 @@ export function formatServerDetails(
 
   if (isHttpServer(config)) {
     lines.push(`${color('Transport:', colors.bold)} HTTP`);
-    lines.push(`${color('URL:', colors.bold)} ${config.url}`);
+    lines.push(`${color('URL:', colors.bold)} ${redactSensitiveUrl(config.url)}`);
   } else {
     const argCount = config.args?.length || 0;
     const commandLabel = basename(config.command);

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -16,6 +16,7 @@ import {
   getTimeoutMs,
   getConcurrencyLimit,
   shouldStreamServerStderr,
+  listTools,
 } from '../src/client';
 
 describe('client', () => {
@@ -100,6 +101,39 @@ describe('client', () => {
       expect(isTransientError(new Error('Port 5029 is in use'))).toBe(false);
       // Should NOT match - network is just part of a word
       expect(isTransientError(new Error('social network tool failed'))).toBe(false);
+    });
+  });
+
+  describe('listTools pagination', () => {
+    test('collects tools across multiple pages when the server returns a nextCursor', async () => {
+      const pages = [
+        {
+          tools: [
+            { name: 'tool_a', description: 'A', inputSchema: {} },
+            { name: 'tool_b', description: 'B', inputSchema: {} },
+          ],
+          nextCursor: 'page-2',
+        },
+        {
+          tools: [
+            { name: 'tool_c', description: 'C', inputSchema: {} },
+          ],
+        },
+      ];
+
+      let callCount = 0;
+      const cursors: unknown[] = [];
+      const client = {
+        async listTools(params?: { cursor?: string }) {
+          cursors.push(params?.cursor);
+          return pages[callCount++];
+        },
+      } as any;
+
+      const tools = await listTools(client);
+
+      expect(tools.map((t) => t.name)).toEqual(['tool_a', 'tool_b', 'tool_c']);
+      expect(cursors).toEqual([undefined, 'page-2']);
     });
   });
 

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -15,6 +15,7 @@ import {
   isTransientError,
   getTimeoutMs,
   getConcurrencyLimit,
+  shouldStreamServerStderr,
 } from '../src/client';
 
 describe('client', () => {
@@ -237,6 +238,33 @@ describe('client', () => {
     test('ignores negative values', () => {
       process.env.MCP_RETRY_DELAY = '-500';
       expect(getRetryDelayMs()).toBe(1000);
+    });
+  });
+
+  describe('shouldStreamServerStderr', () => {
+    const originalEnv = process.env.MCP_DEBUG;
+
+    afterEach(() => {
+      if (originalEnv !== undefined) {
+        process.env.MCP_DEBUG = originalEnv;
+      } else {
+        delete process.env.MCP_DEBUG;
+      }
+    });
+
+    test('returns false by default (quiet mode)', () => {
+      delete process.env.MCP_DEBUG;
+      expect(shouldStreamServerStderr()).toBe(false);
+    });
+
+    test('returns true when MCP_DEBUG=1', () => {
+      process.env.MCP_DEBUG = '1';
+      expect(shouldStreamServerStderr()).toBe(true);
+    });
+
+    test('returns true when MCP_DEBUG is set to any value', () => {
+      process.env.MCP_DEBUG = 'true';
+      expect(shouldStreamServerStderr()).toBe(true);
     });
   });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -128,6 +128,35 @@ describe('config', () => {
       await expect(loadConfig(configPath)).rejects.toThrow('MISSING_ENV_VAR');
     });
 
+    test('only substitutes env vars for targeted servers', async () => {
+      delete process.env.MCP_STRICT_ENV;
+
+      const configPath = join(tempDir, 'targeted_env.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            chrome: {
+              command: 'echo',
+              args: ['ok'],
+            },
+            context7: {
+              command: 'echo',
+              env: { API_KEY: '${MISSING_CONTEXT7_API_KEY}' },
+            },
+          },
+        })
+      );
+
+      const config = await loadConfig({
+        explicitPath: configPath,
+        serverNames: ['chrome'],
+      });
+
+      expect((config.mcpServers.chrome as any).command).toBe('echo');
+      expect((config.mcpServers.context7 as any).env.API_KEY).toBe('${MISSING_CONTEXT7_API_KEY}');
+    });
+
     test('throws error on empty server config', async () => {
       const configPath = join(tempDir, 'empty_server.json');
       await writeFile(

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -6,6 +6,7 @@ import { describe, test, expect } from 'bun:test';
 import {
   formatServerList,
   formatSearchResults,
+  formatServerDetails,
   formatToolSchema,
   formatToolResult,
   formatJson,
@@ -98,6 +99,35 @@ describe('output', () => {
 
       const withoutDesc = formatSearchResults(results, false);
       expect(withoutDesc).toContain('Tool description');
+    });
+  });
+
+
+  describe('formatServerDetails', () => {
+    test('hides stdio args to avoid leaking secrets', () => {
+      const output = formatServerDetails(
+        'secrets',
+        {
+          command: '/usr/local/bin/node',
+          args: ['server.js', '--api-key', 'super-secret-value'],
+        },
+        [],
+      );
+
+      expect(output).toContain('Command: node (3 args hidden)');
+      expect(output).not.toContain('super-secret-value');
+      expect(output).not.toContain('--api-key');
+      expect(output).not.toContain('/usr/local/bin/node');
+    });
+
+    test('shows stdio command basename when there are no args', () => {
+      const output = formatServerDetails(
+        'simple',
+        { command: '/opt/mcp/server' },
+        [],
+      );
+
+      expect(output).toContain('Command: server');
     });
   });
 

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -120,6 +120,22 @@ describe('output', () => {
       expect(output).not.toContain('/usr/local/bin/node');
     });
 
+    test('redacts credentials and secret query params in http urls', () => {
+      const output = formatServerDetails(
+        'remote',
+        {
+          url: 'https://alice:super-secret@example.com/mcp?api_key=top-secret&token=abc123&safe=yes',
+        },
+        [],
+      );
+
+      expect(output).toContain('URL: https://***:***@example.com/mcp?api_key=***&token=***&safe=yes');
+      expect(output).not.toContain('alice');
+      expect(output).not.toContain('super-secret');
+      expect(output).not.toContain('top-secret');
+      expect(output).not.toContain('abc123');
+    });
+
     test('shows stdio command basename when there are no args', () => {
       const output = formatServerDetails(
         'simple',


### PR DESCRIPTION
## Summary
- hide stdio argument values in `mcp-cli info <server>` output
- show only the command basename plus the number of hidden args
- add coverage to ensure secrets and full paths do not leak through formatted server details

## Why
Issue #217 reports that `mcp-cli info` can reveal secret strings by printing the full configured command line.

This keeps the command recognizable for debugging, while avoiding accidental disclosure of secret-bearing args such as API keys or tokens.

## Testing
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

Fixes #217
