### PR TITLE
fix: add recovery hints for stateful server connection errors

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -134,6 +134,13 @@ export function serverConnectionError(
   } else if (cause.includes('ETIMEDOUT') || cause.includes('timeout')) {
     suggestion =
       'Connection timed out. Check network connectivity and server availability';
+  } else if (
+    cause.includes('already running') ||
+    cause.includes('profile is locked') ||
+    cause.includes('Use --isolated')
+  ) {
+    suggestion =
+      'This looks like a stateful server reusing a locked profile. Keep daemon mode enabled so mcp-cli can reuse the same server connection, and only use --isolated when you intentionally want a separate fresh instance.';
   } else if (cause.includes('401') || cause.includes('Unauthorized')) {
     suggestion = 'Authentication required. Add Authorization header to config';
   } else if (cause.includes('403') || cause.includes('Forbidden')) {

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -120,6 +120,16 @@ describe('errors', () => {
       const error = serverConnectionError('remote', '401 Unauthorized');
       expect(error.suggestion).toContain('Authorization header');
     });
+
+    test('serverConnectionError detects stateful server profile lock hints', () => {
+      const error = serverConnectionError(
+        'chrome-devtools',
+        'The browser is already running for /tmp/chrome-profile. Use --isolated to run multiple browser instances.',
+      );
+      expect(error.suggestion).toContain('daemon mode');
+      expect(error.suggestion).toContain('--isolated');
+      expect(error.suggestion).toContain('same server connection');
+    });
   });
 
   describe('tool errors', () => {


### PR DESCRIPTION
## Summary
- detect stateful server profile-lock errors in `serverConnectionError()`
- suggest keeping daemon mode enabled so mcp-cli can reuse the same server connection
- mention `--isolated` only for intentionally fresh instances

## Related Issues
Part of #21

## Testing
- `bun test tests/errors.test.ts`
