### PR TITLE
fix(info): hide server connection details

### DIFF
--- a/src/output.ts
+++ b/src/output.ts
@@ -115,12 +115,8 @@ export function formatServerDetails(
 
   if (isHttpServer(config)) {
     lines.push(`${color('Transport:', colors.bold)} HTTP`);
-    lines.push(`${color('URL:', colors.bold)} ${config.url}`);
   } else {
     lines.push(`${color('Transport:', colors.bold)} stdio`);
-    lines.push(
-      `${color('Command:', colors.bold)} ${config.command} ${(config.args || []).join(' ')}`,
-    );
   }
 
   if (instructions) {

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, test, expect } from 'bun:test';
 import {
+  formatServerDetails,
   formatServerList,
   formatSearchResults,
   formatToolSchema,
@@ -98,6 +99,41 @@ describe('output', () => {
 
       const withoutDesc = formatSearchResults(results, false);
       expect(withoutDesc).toContain('Tool description');
+    });
+  });
+
+  describe('formatServerDetails', () => {
+    test('shows transport without stdio command details', () => {
+      const output = formatServerDetails(
+        'filesystem',
+        {
+          command: 'npx',
+          args: ['-y', '@modelcontextprotocol/server-filesystem', '.'],
+        },
+        [],
+      );
+
+      expect(output).toContain('Server:');
+      expect(output).toContain('filesystem');
+      expect(output).toContain('Transport:');
+      expect(output).toContain('stdio');
+      expect(output).not.toContain('Command:');
+      expect(output).not.toContain('@modelcontextprotocol/server-filesystem');
+    });
+
+    test('shows transport without http endpoint details', () => {
+      const output = formatServerDetails(
+        'deepwiki',
+        { url: 'https://mcp.deepwiki.com/mcp' },
+        [],
+      );
+
+      expect(output).toContain('Server:');
+      expect(output).toContain('deepwiki');
+      expect(output).toContain('Transport:');
+      expect(output).toContain('HTTP');
+      expect(output).not.toContain('URL:');
+      expect(output).not.toContain('https://mcp.deepwiki.com/mcp');
     });
   });
 


### PR DESCRIPTION
## Summary
- stop `mcp-cli info <server>` from echoing stdio command/args
- stop `mcp-cli info <server>` from echoing HTTP endpoint URLs
- add output tests to lock in the less-sensitive server detail format

## Why
Closes #217.

The `info` command is primarily for understanding transport type, instructions, and exposed tools. Echoing the exact connection command, args, or remote URL creates avoidable leakage of sensitive runtime details without helping the common discovery workflow.

## Testing
- `bun test tests/output.test.ts`
