### PR TITLE
docs(config): align documented search paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ bun install -g https://github.com/philschmid/mcp-cli
 
 ### 2. Create a config file
 
-Create `mcp_servers.json` in your current directory or `~/.config/mcp/`:
+Create `mcp_servers.json` in your current directory, `~/.mcp_servers.json`, or `~/.config/mcp/mcp_servers.json`:
 
 ```json
 {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -68,7 +68,7 @@ export function configSearchError(): CliError {
     details:
       'Searched: ./mcp_servers.json, ~/.mcp_servers.json, ~/.config/mcp/mcp_servers.json',
     suggestion:
-      'Create mcp_servers.json in current directory or use -c/--config to specify path',
+      'Create mcp_servers.json in the current directory, ~/.mcp_servers.json, or ~/.config/mcp/mcp_servers.json, or use -c/--config to specify a path',
   };
 }
 


### PR DESCRIPTION
## Summary
- update the README quick-start config location text to include `~/.mcp_servers.json`
- update the config-not-found suggestion to match the actual search order already described by the CLI help

## Why
The CLI already searches `./mcp_servers.json`, `~/.mcp_servers.json`, and `~/.config/mcp/mcp_servers.json`, but the quick-start text and one error suggestion only mentioned a subset of those paths. This keeps the user-facing guidance consistent with the real search behavior.

## Testing
- docs / error-message consistency change only
