### PR TITLE
fix(errors): use info command in schema hints

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -184,9 +184,9 @@ export function toolExecutionError(
 
   // Detect common MCP error patterns
   if (cause.includes('validation') || cause.includes('invalid_type')) {
-    suggestion = `Run 'mcp-cli ${serverName}/${toolName}' to see the input schema, then fix arguments`;
+    suggestion = `Run 'mcp-cli info ${serverName} ${toolName}' to see the input schema, then fix arguments`;
   } else if (cause.includes('required')) {
-    suggestion = `Missing required argument. Run 'mcp-cli ${serverName}/${toolName}' to see required fields`;
+    suggestion = `Missing required argument. Run 'mcp-cli info ${serverName} ${toolName}' to see required fields`;
   } else if (cause.includes('permission') || cause.includes('denied')) {
     suggestion = 'Permission denied. Check file/resource permissions';
   } else if (cause.includes('not found') || cause.includes('ENOENT')) {


### PR DESCRIPTION
## Summary
- update tool-execution validation hints to recommend `mcp-cli info <server> <tool>`
- remove outdated slash-format guidance from these error suggestions

## Why
The CLI's formal syntax for viewing a tool schema is `mcp-cli info <server> <tool>`, but `toolExecutionError()` still suggested the older `server/tool` style. Keeping error hints aligned with the current command surface avoids sending users toward deprecated or less-clear syntax.

## Testing
- string-only error-hint update
