### PR TITLE
docs(help): clarify primary target format

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -224,8 +224,8 @@ export function invalidTargetError(target: string): CliError {
     code: ErrorCode.CLIENT_ERROR,
     type: 'INVALID_TARGET',
     message: `Invalid target format: "${target}"`,
-    details: 'Expected format: server/tool',
-    suggestion: `Use 'mcp-cli <server>/<tool> <json>' format, e.g., 'mcp-cli github/search_repos \'{"query":"mcp"}\''`,
+    details: 'Expected a server/tool target (or separate <server> <tool> arguments after the subcommand)',
+    suggestion: `Use 'mcp-cli call <server> <tool> <json>' format, e.g., 'mcp-cli call github search_repos \'{"query":"mcp"}\''`,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -356,11 +356,11 @@ Usage:
   mcp-cli [options] call <server> <tool>         Call tool (reads JSON from stdin if no args)
   mcp-cli [options] call <server> <tool> <json>  Call tool with JSON arguments
 
-Formats (both work):
-  mcp-cli info server tool                       Space-separated
-  mcp-cli info server/tool                       Slash-separated
-  mcp-cli call server tool '{}'                  Space-separated
-  mcp-cli call server/tool '{}'                  Slash-separated
+Formats (space-separated is the primary form):
+  mcp-cli info server tool                       Primary form
+  mcp-cli info server/tool                       Also supported
+  mcp-cli call server tool '{}'                  Primary form
+  mcp-cli call server/tool '{}'                  Also supported
 
 Options:
   -h, --help               Show this help message


### PR DESCRIPTION
## Summary
- update invalid-target guidance to recommend the current primary `call <server> <tool> <json>` form
- clarify in `--help` that space-separated targets are the primary form and slash-separated targets are still supported

## Why
The CLI still supports slash-separated targets, but the current command surface and recent error-hint cleanup have moved toward `info <server> <tool>` / `call <server> <tool>`. This keeps help and parse-error guidance aligned with that primary syntax while preserving mention of the compatibility form.

## Testing
- help / error-message wording change only
