### PR TITLE
docs: align config search error with merge behavior

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -64,11 +64,11 @@ export function configSearchError(): CliError {
   return {
     code: ErrorCode.CLIENT_ERROR,
     type: 'CONFIG_NOT_FOUND',
-    message: 'No mcp_servers.json found in search paths',
+    message: 'No default mcp_servers.json files found to merge',
     details:
-      'Searched: ./mcp_servers.json, ~/.mcp_servers.json, ~/.config/mcp/mcp_servers.json',
+      'Checked default paths: ./mcp_servers.json, ~/.mcp_servers.json, ~/.config/mcp/mcp_servers.json',
     suggestion:
-      'Create mcp_servers.json in current directory or use -c/--config to specify path',
+      'Create mcp_servers.json in one of the default paths, or use -c/--config / MCP_CONFIG_PATH to specify a file explicitly',
   };
 }
 


### PR DESCRIPTION
$## Summary\n- update the default config search error to match the new merge-based behavior\n- replace the old "search paths" wording with explicit default-path merge wording\n- clarify that `-c/--config` and `MCP_CONFIG_PATH` still opt into a single explicit file\n\nFollow-up to #28\n\n## Validation\n- ./node_modules/.bin/tsc --noEmit