### PR TITLE
fix: redact stdio command args in info

### DIFF
--- a/src/output.ts
+++ b/src/output.ts
@@ -2,6 +2,7 @@
  * Output formatting utilities
  */
 
+import { basename } from 'node:path';
 import type { ToolInfo } from './client.js';
 import type { ServerConfig } from './config.js';
 import { isHttpServer } from './config.js';
@@ -98,6 +99,21 @@ export function formatSearchResults(
 }
 
 /**
+ * Format stdio command details without leaking full argument values.
+ */
+function formatStdioCommand(command: string, args?: string[]): string {
+  const executable = basename(command);
+  const argCount = args?.length ?? 0;
+
+  if (argCount === 0) {
+    return executable;
+  }
+
+  const suffix = argCount === 1 ? 'argument' : 'arguments';
+  return `${executable} (${argCount} hidden ${suffix})`;
+}
+
+/**
  * Format server details
  */
 export function formatServerDetails(
@@ -119,7 +135,7 @@ export function formatServerDetails(
   } else {
     lines.push(`${color('Transport:', colors.bold)} stdio`);
     lines.push(
-      `${color('Command:', colors.bold)} ${config.command} ${(config.args || []).join(' ')}`,
+      `${color('Command:', colors.bold)} ${formatStdioCommand(config.command, config.args)}`,
     );
   }
 

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -2,14 +2,15 @@
  * Unit tests for output formatting
  */
 
-import { describe, test, expect } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 import {
-  formatServerList,
-  formatSearchResults,
-  formatToolSchema,
-  formatToolResult,
-  formatJson,
   formatError,
+  formatJson,
+  formatSearchResults,
+  formatServerDetails,
+  formatServerList,
+  formatToolResult,
+  formatToolSchema,
 } from '../src/output';
 
 // Disable colors for testing
@@ -98,6 +99,36 @@ describe('output', () => {
 
       const withoutDesc = formatSearchResults(results, false);
       expect(withoutDesc).toContain('Tool description');
+    });
+  });
+
+  describe('formatServerDetails', () => {
+    test('redacts stdio args in server info output', () => {
+      const output = formatServerDetails(
+        'secret-server',
+        {
+          command: '/usr/bin/node',
+          args: ['server.js', '--api-key', 'super-secret-token'],
+        },
+        [],
+      );
+
+      expect(output).toContain('Command: node (3 hidden arguments)');
+      expect(output).not.toContain('super-secret-token');
+      expect(output).not.toContain('--api-key');
+      expect(output).not.toContain('server.js');
+    });
+
+    test('shows plain executable when stdio server has no args', () => {
+      const output = formatServerDetails(
+        'simple-server',
+        {
+          command: '/usr/local/bin/uvx',
+        },
+        [],
+      );
+
+      expect(output).toContain('Command: uvx');
     });
   });
 


### PR DESCRIPTION
## Summary
- redact stdio server args in `mcp-cli info` output
- keep the executable name visible while hiding the full argument list
- add output-format regression tests for both arg and no-arg stdio servers

## Problem
Issue #217 reports that `mcp-cli info` can reveal secret-bearing command details. The existing `info` output still printed the entire stdio command line, including raw args.

## Fix
`formatServerDetails()` now renders stdio commands as `<executable> (<N> hidden arguments)` instead of echoing the full arg list. This preserves useful context without leaking flags, paths, or tokens embedded in args.

Fixes #217

## Validation
- `bun test tests/output.test.ts`
- `npx tsc --noEmit`
- `npx @biomejs/biome check src/output.ts tests/output.test.ts`
- `git diff --check`
