### PR TITLE
fix: flush large piped tool output

### DIFF
--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -7,6 +7,7 @@
  * - Errors always go to stderr
  */
 
+import { once } from 'node:events';
 import {
   type McpConnection,
   debug,
@@ -104,6 +105,14 @@ async function parseArgs(
   }
 }
 
+async function writeStdout(output: string): Promise<void> {
+  if (process.stdout.write(`${output}\n`)) {
+    return;
+  }
+
+  await once(process.stdout, 'drain');
+}
+
 /**
  * Execute the call command
  */
@@ -163,7 +172,7 @@ export async function callCommand(options: CallOptions): Promise<void> {
 
     // Extract text content from MCP response for CLI-friendly output
     // Uses formatToolResult which extracts text from MCP content array
-    console.log(formatToolResult(result));
+    await writeStdout(formatToolResult(result));
   } catch (error) {
     // Try to get available tools for better error message
     let availableTools: string[] | undefined;


### PR DESCRIPTION
## Summary
- replace `console.log()` in `call` output with an explicit stdout writer
- wait for `drain` when stdout backpressure is applied
- preserve the existing CLI-friendly text output format

## Problem
Issue #23 reports that large tool results are truncated at 65536 bytes when `mcp-cli call ...` is piped to another process. This points to the output path not respecting pipe backpressure.

## Fix
The `call` command now writes formatted tool output through `process.stdout.write()` and awaits the `drain` event when needed, instead of relying on `console.log()`. That keeps the same output shape while ensuring large responses are fully flushed through piped stdout.

Fixes #23

## Validation
- `git diff --check`
- `npx tsc --noEmit`
- `bun test tests/config.test.ts`
- `bun test tests/output.test.ts`
- `npx @biomejs/biome check src/commands/call.ts`
