### PR TITLE
fix: only show server stderr in debug mode

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -244,14 +244,16 @@ export async function connectToServer(
       transport = createStdioTransport(config);
 
       // Capture stderr for debugging - attach BEFORE connect
-      // Always stream stderr immediately so auth prompts are visible
       const stderrStream = transport.stderr;
       if (stderrStream) {
         stderrStream.on('data', (chunk: Buffer) => {
           const text = chunk.toString();
           stderrChunks.push(text);
-          // Always stream stderr immediately so users can see auth prompts
-          process.stderr.write(`[${serverName}] ${text}`);
+
+          // Only forward live stderr in debug mode to avoid noisy token burn.
+          if (process.env.MCP_DEBUG) {
+            process.stderr.write(`[${serverName}] ${text}`);
+          }
         });
       }
     }
@@ -268,15 +270,8 @@ export async function connectToServer(
       throw error;
     }
 
-    // For successful connections, forward stderr to console
-    if (!isHttpServer(config)) {
-      const stderrStream = (transport as StdioClientTransport).stderr;
-      if (stderrStream) {
-        stderrStream.on('data', (chunk: Buffer) => {
-          process.stderr.write(chunk);
-        });
-      }
-    }
+    // For successful connections, stderr has already been captured above.
+    // It is only forwarded live when MCP_DEBUG is enabled.
 
     return {
       client,

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,10 @@ function parseArgs(args: string[]): ParsedArgs {
         result.command = 'version';
         return result;
 
+      case '--debug':
+        process.env.MCP_DEBUG = '1';
+        break;
+
       case '-d':
       case '--with-descriptions':
         result.withDescriptions = true;
@@ -367,6 +371,7 @@ Options:
   -v, --version            Show version number
   -d, --with-descriptions  Include tool descriptions
   -c, --config <path>      Path to mcp_servers.json config file
+  --debug                  Show MCP server stderr/debug output
 
 Output:
   mcp-cli/info/grep        Human-readable text to stdout
@@ -385,6 +390,7 @@ Examples:
 Environment Variables:
   MCP_NO_DAEMON=1        Disable connection caching (force fresh connections)
   MCP_DAEMON_TIMEOUT=N   Set daemon idle timeout in seconds (default: 60)
+  MCP_DEBUG=1            Show MCP server stderr/debug output
 
 Config File:
   The CLI looks for mcp_servers.json in:


### PR DESCRIPTION
## Summary
- stop forwarding MCP server stderr during successful stdio sessions by default
- add a `--debug` CLI flag that enables the existing `MCP_DEBUG` behavior
- keep captured stderr attached to connection errors for debugging failures

## Problem
Issue #17 notes that `mcp-cli` always prints server stderr, which adds noisy output for agentic and scripted usage even when the command itself succeeds.

## Fix
The stdio client now captures stderr for diagnostics but only forwards it live when debug mode is enabled. This preserves stderr context on connection failures while making normal command output quiet by default. The CLI also gains a `--debug` flag that sets `MCP_DEBUG=1` for one-off debugging runs.

Fixes #17

## Validation
- `git diff --check`
- `npx tsc --noEmit`
- `bun test tests/config.test.ts`
- `bun test tests/output.test.ts`
- `npx @biomejs/biome check src/client.ts src/index.ts`
