### PR TITLE
docs: refresh debug and config resolution help

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,13 +339,16 @@ Restrict which tools are available from a server using `allowedTools` and `disab
 
 ### Config Resolution
 
-The CLI searches for configuration in this order:
+The CLI resolves configuration like this:
 
-1. `MCP_CONFIG_PATH` environment variable
-2. `-c/--config` command line argument
-3. `./mcp_servers.json` (current directory)
-4. `~/.mcp_servers.json`
-5. `~/.config/mcp/mcp_servers.json`
+1. If `MCP_CONFIG_PATH` is set, load only that file
+2. If `-c/--config <path>` is provided, load only that file
+3. Otherwise, merge all existing default config paths in precedence order:
+   - `~/.config/mcp/mcp_servers.json`
+   - `~/.mcp_servers.json`
+   - `./mcp_servers.json` (current directory)
+
+When the same server name appears in multiple default config files, the higher-precedence file overrides the lower-precedence one.
 
 ### Environment Variables
 
@@ -475,7 +478,8 @@ By default, the CLI uses **lazy-spawn connection pooling** to avoid repeated MCP
 ```bash
 MCP_NO_DAEMON=1 mcp-cli info      # Force fresh connection
 MCP_DAEMON_TIMEOUT=120 mcp-cli    # 2 minute idle timeout
-MCP_DEBUG=1 mcp-cli info          # See daemon debug output
+MCP_DEBUG=1 mcp-cli info          # See daemon + server debug output
+mcp-cli --debug info filesystem   # One-off debug mode without exporting env vars
 ```
 
 ### Connection Model (Direct)

--- a/src/index.ts
+++ b/src/index.ts
@@ -367,6 +367,7 @@ Options:
   -v, --version            Show version number
   -d, --with-descriptions  Include tool descriptions
   -c, --config <path>      Path to mcp_servers.json config file
+  --debug                  Show MCP server stderr/debug output
 
 Output:
   mcp-cli/info/grep        Human-readable text to stdout
@@ -385,12 +386,15 @@ Examples:
 Environment Variables:
   MCP_NO_DAEMON=1        Disable connection caching (force fresh connections)
   MCP_DAEMON_TIMEOUT=N   Set daemon idle timeout in seconds (default: 60)
+  MCP_DEBUG=1            Show MCP server stderr/debug output
 
 Config File:
-  The CLI looks for mcp_servers.json in:
-    1. Path specified by MCP_CONFIG_PATH or -c/--config
-    2. ./mcp_servers.json (current directory)
-    3. ~/.mcp_servers.json
+  The CLI resolves config like this:
+    1. Path specified by MCP_CONFIG_PATH or -c/--config (single file)
+    2. Otherwise merge all existing default config files with precedence:
+       ~/.config/mcp/mcp_servers.json
+       ~/.mcp_servers.json
+       ./mcp_servers.json (current directory)
     4. ~/.config/mcp/mcp_servers.json
 `);
 }


### PR DESCRIPTION
## Summary
- document merged default config loading in the README and CLI help
- add the new `--debug` flag to help output and debugging examples
- align the user-facing docs with the current runtime behavior

## Problem
Several recent UX improvements are implemented but not yet reflected in the docs/help output:
- default config discovery now merges multiple config files
- the CLI now supports a one-off `--debug` flag

Without doc updates, users still see stale config resolution behavior and may miss the new debug path.

## Changes
- update the README config resolution section to describe single-file explicit configs vs merged default configs
- add `--debug` to the CLI help output and environment variable list
- add a one-off debug example in the README connection pooling section

## Validation
- `git diff --check`
- `npx tsc --noEmit`
- `npx @biomejs/biome check src/index.ts README.md`
