### PR TITLE
docs: clarify linux arm64 install fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ A lightweight, Bun-based CLI for interacting with [MCP (Model Context Protocol)]
 curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh | bash
 ```
 
+> [!NOTE]
+> The release installer currently depends on published platform binaries. If you are on **Linux arm64 / aarch64** and the latest release does not include `mcp-cli-linux-arm64`, the install script will fail over to a source install recommendation instead of succeeding.
+
 or 
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,16 @@ CHECKSUM_URL="https://github.com/$GITHUB_REPO/releases/latest/download/checksums
 echo -e "${BLUE}Downloading...${NC}"
 TMP_FILE=$(mktemp)
 if ! curl -fsSL "$DOWNLOAD_URL" -o "$TMP_FILE"; then
-    echo -e "${RED}Failed to download binary. Check if releases exist at:${NC}"
+    echo -e "${RED}Failed to download binary.${NC}"
+    echo "  URL: $DOWNLOAD_URL"
+    echo ""
+    if [ "$OS" = "linux" ] && [ "$ARCH" = "aarch64" ]; then
+        echo -e "${YELLOW}Linux arm64 release asset not found for the latest release.${NC}"
+        echo "Try installing from source instead:"
+        echo "  bun install -g https://github.com/$GITHUB_REPO"
+        echo ""
+    fi
+    echo -e "${RED}Check available releases at:${NC}"
     echo "  https://github.com/$GITHUB_REPO/releases"
     exit 1
 fi


### PR DESCRIPTION
## Summary
- document the Linux arm64 release-asset gap in the README install section
- improve `install.sh` download failure output for Linux aarch64
- point affected users to the Bun/source install fallback

## Problem
Issue #24 reports that the release installer fails on Linux arm64 because the script looks for `mcp-cli-linux-arm64` and gets a 404 when that asset is missing from the latest release. The current error is generic and does not tell users what to do next.

## Changes
- add a README note explaining the current Linux arm64 release-binary limitation
- update `install.sh` to print the missing asset URL and a source-install fallback when the failing platform is Linux aarch64
- keep the existing release-based install path unchanged for platforms with published binaries

Fixes #24

## Validation
- `bash -n install.sh`
- `git diff --check`
