### PR TITLE
docs: add noisy server troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,24 @@ For Code Agents that support Agents Skills, like Gemini CLI, OpenCode or Claude 
 
 Create `mcp-cli/SKILL.md` in your skills directory. 
 
+## Troubleshooting noisy MCP servers
+
+Some MCP servers print informational logs to **stderr** during startup, watcher registration, or shutdown. This is especially common for language-server wrappers such as `mcp-language-server`, FastMCP-based servers, or tools that manage file watchers behind the scenes.
+
+Typical examples include:
+- watcher registration messages
+- LSP lifecycle warnings during shutdown
+- banner output from wrapped runtimes
+- broken pipe noise after the CLI terminates a stdio session
+
+If `mcp-cli` still lists tools successfully or returns a valid tool result, the server is usually functioning and you're seeing server-side log noise rather than a CLI failure.
+
+**How to evaluate it:**
+- Run `mcp-cli info <server>` to isolate one noisy server.
+- Use `mcp-cli --debug ...` (or `MCP_DEBUG=1`) when you explicitly want live stderr.
+- Expect extra shutdown chatter from stateful or watcher-heavy stdio servers.
+- Treat successful tool discovery / execution as the primary signal that the MCP integration is working.
+
 ## Architecture
 
 ### Connection Pooling (Daemon)


### PR DESCRIPTION
## Summary
- add a README troubleshooting section for noisy MCP servers
- explain why LSP wrappers / watcher-heavy servers may log to stderr even when tools work
- point users to `mcp-cli --debug` / `MCP_DEBUG=1` for intentional stderr inspection

## Problem
Issue #3 shows a config that works but produces a large amount of stderr noise from `mcp-language-server` and related wrapped runtimes. Without troubleshooting guidance, users can read that output as a CLI failure even when tool discovery succeeds.

## Changes
- add a dedicated README troubleshooting section for noisy MCP servers
- describe common categories of startup/shutdown stderr noise
- explain how to isolate one server and when to treat the logs as server-side chatter rather than a broken CLI config

Fixes #3

## Validation
- `git diff --check`
